### PR TITLE
Fix array to string conversion in REST::sendRequest()

### DIFF
--- a/src/Storage/Connection/REST.php
+++ b/src/Storage/Connection/REST.php
@@ -225,7 +225,7 @@ class REST implements ConnectionInterface
     private function loadServiceDefinition()
     {
         return json_decode(
-            file_get_contents('ServiceDefinition/storage-v1.json', true),
+            file_get_contents(__DIR__ . '/ServiceDefinition/storage-v1.json', true),
             true
         );
     }

--- a/src/Storage/Connection/REST.php
+++ b/src/Storage/Connection/REST.php
@@ -240,7 +240,7 @@ class REST implements ConnectionInterface
     {
         // @todo quick POC. need to tighten this up
         $action = $this->service[$resource]['methods'][$method];
-        $template = new UriTemplate();
+        $template = new UriTemplate(self::BASE_URI);
         $path = [];
         $query = [];
         $body = [];
@@ -260,7 +260,7 @@ class REST implements ConnectionInterface
         }
 
         $uri = $this->buildUri(
-            $template->expand($action['path'], self::BASE_URI . $path),
+            $template->expand($action['path'], $path),
             $query
         );
 

--- a/tests/Storage/Connection/RESTTest.php
+++ b/tests/Storage/Connection/RESTTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Gcloud\Tests\Storage\Connection;
+
+use Google\Gcloud\HttpRequestWrapper;
+use Google\Gcloud\Storage\Connection\REST;
+use Psr\Http\Message\ResponseInterface;
+
+class RESTTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetObjectReturnsResponseArray()
+    {
+        $response = $this->getMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn('{"name": "foo.txt"}');
+
+        $wrapper = $this->getMock(HttpRequestWrapper::class);
+        $wrapper->method('send')->willReturn($response);
+
+        $object = (new REST($wrapper))->getObject();
+
+        $this->assertEquals(['name' => 'foo.txt'], $object);
+    }
+}


### PR DESCRIPTION
Minimum viable test for an array to string conversion error in `REST::sendRequest()`.

Before:

```bash
$ vendor/bin/phpunit
PHPUnit 4.8.23 by Sebastian Bergmann and contributors.

........................E.............

Time: 178 ms, Memory: 8.00Mb

There was 1 error:

1) Google\Gcloud\Tests\Storage\Connection\RESTTest::testGetObjectReturnsResponseArray
Array to string conversion

/Users/mike/Code/mcrumm/gcloud-php/src/Storage/Connection/REST.php:263
/Users/mike/Code/mcrumm/gcloud-php/src/Storage/Connection/REST.php:152
/Users/mike/Code/mcrumm/gcloud-php/tests/Storage/Connection/RESTTest.php:39

FAILURES!
Tests: 38, Assertions: 40, Errors: 1.
```

FWIW, I found this repo last night while looking for a [flysystem](flysystem.thephpleague.com) adapter for GCP.  Not finding one that I liked, I set out to write one using gcloud-php as its base.  This was the last of the issues I encountered while working on the initial implementation.