### PR TITLE
Rewind the keyFileStream before each read

### DIFF
--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -173,6 +173,7 @@ class RequestWrapper
         }
 
         if ($this->keyFileStream) {
+            $this->keyFileStream->rewind();
             return CredentialsLoader::makeCredentials($this->scopes, $this->keyFileStream);
         }
 

--- a/tests/RequestWrapperTest.php
+++ b/tests/RequestWrapperTest.php
@@ -104,6 +104,19 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @dataProvider keyFileCredentialsProvider
+     */
+    public function testCredentialsFromKeyFileStreamCanBeReadMultipleTimes($wrapperConfig)
+    {
+        $requestWrapper = new RequestWrapper($wrapperConfig);
+
+        $requestWrapper->getCredentialsFetcher();
+        $credentials = $requestWrapper->getCredentialsFetcher();
+
+        $this->assertInstanceOf('Google\Auth\FetchAuthTokenInterface', $credentials);
+    }
+
     public function credentialsProvider()
     {
         $config = [
@@ -127,6 +140,25 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
             [$config + ['keyFilePath' => $keyFilePath]], //keyFilePath
             [$config + ['credentialsFetcher' => $credentialsFetcher->reveal()]], // user supplied fetcher
             [$config] // application default
+        ];
+    }
+
+    public function keyFileCredentialsProvider()
+    {
+        $config = [
+            'authHttpHandler' => function ($request, $options = []) {
+                return new Response(200, [], json_encode(['access_token' => 'abc']));
+            },
+            'httpHandler' => function ($request, $options = []) {
+                return new Response(200, []);
+            }
+        ];
+
+        $keyFilePath = __DIR__ . '/fixtures/json-key-fixture.json';
+
+        return [
+            [$config + ['keyFile' => file_get_contents($keyFilePath)]], // keyFile
+            [$config + ['keyFilePath' => $keyFilePath]], //keyFilePath
         ];
     }
 


### PR DESCRIPTION
When using either `keyFile` or `keyFileStream` to provide credentials to the `ServiceBuilder`, if the user's credentials expire between requests, an error will occur when trying to load credentials from the file stream, because the pointer is at the end of the stream.

Here's the output from the test prior to calling `$keyFileStream->rewind()` within the `ServiceBuilder`:

```
PHPUnit 5.1.3 by Sebastian Bergmann and contributors.

.....................EE.......................................... 65 / 96 ( 67%)
...............................                                   96 / 96 (100%)

Time: 250 ms, Memory: 16.77Mb

There were 2 errors:

1) Google\Cloud\Tests\RequestWrapperTest::testCredentialsFromKeyFileStreamCanBeReadMultipleTimes with data set #0 (array(Closure Object (...), Closure Object (...), '{"type":"authorized_user","cl..."abc"}'))
array_key_exists() expects parameter 2 to be array, null given

/Users/mike/Code/mcrumm/gcloud-php/vendor/google/auth/src/CredentialsLoader.php:118
/Users/mike/Code/mcrumm/gcloud-php/src/RequestWrapper.php:177
/Users/mike/Code/mcrumm/gcloud-php/tests/RequestWrapperTest.php:115

2) Google\Cloud\Tests\RequestWrapperTest::testCredentialsFromKeyFileStreamCanBeReadMultipleTimes with data set #1 (array(Closure Object (...), Closure Object (...), '/Users/mike/Code/mcrumm/gclou...e.json'))
array_key_exists() expects parameter 2 to be array, null given

/Users/mike/Code/mcrumm/gcloud-php/vendor/google/auth/src/CredentialsLoader.php:118
/Users/mike/Code/mcrumm/gcloud-php/src/RequestWrapper.php:177
/Users/mike/Code/mcrumm/gcloud-php/tests/RequestWrapperTest.php:115

FAILURES!
Tests: 96, Assertions: 115, Errors: 2.
```