### PR TITLE
Detect contentType in the storage REST handler

### DIFF
--- a/src/Storage/Connection/Rest.php
+++ b/src/Storage/Connection/Rest.php
@@ -264,7 +264,7 @@ class Rest implements ConnectionInterface
         unset($args['name']);
         $args['contentType'] = isset($args['metadata']['contentType'])
             ? $args['metadata']['contentType']
-            : null;
+            : Psr7\mimetype_from_filename($args['metadata']['name']);
 
         $uploaderOptionKeys = [
             'httpOptions',

--- a/src/Upload/AbstractUploader.php
+++ b/src/Upload/AbstractUploader.php
@@ -95,23 +95,14 @@ abstract class AbstractUploader
             'httpOptions' => null,
             'retries' => null
         ]);
+
         $this->contentType = isset($options['contentType'])
             ? $options['contentType']
-            : $this->getContentTypeFromFilename($this->data->getMetadata('uri'));
+            : 'application/octet-stream';
     }
 
     /**
      * @return array
      */
     abstract public function upload();
-
-    /**
-     * Determines the content type.
-     *
-     * @param string $filename
-     */
-    private function getContentTypeFromFilename($filename)
-    {
-        return Psr7\mimetype_from_filename($filename) ?: 'application/octet-stream';
-    }
 }


### PR DESCRIPTION
Content Type detection was not working correctly when uploading from the tmp uploads folder. To fix it, we're trying to detect the content type in the Storage REST connection. If the content type cannot be determined, the object will upload as `application/octet-stream`.