### PR TITLE
Support deeper nesting in the Json Schema

### DIFF
--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -40,13 +40,20 @@ class RequestBuilder
     private $baseUri;
 
     /**
+     * @var array
+     */
+    private $resourceRoot;
+
+    /**
      * @param string $servicePath
      * @param string $baseUri
+     * @param array  $resourceRoot
      */
-    public function __construct($servicePath, $baseUri)
+    public function __construct($servicePath, $baseUri, array $resourceRoot = [])
     {
         $this->service = $this->loadServiceDefinition($servicePath);
         $this->baseUri = $baseUri;
+        $this->resourceRoot = $resourceRoot;
     }
 
     /**
@@ -61,11 +68,18 @@ class RequestBuilder
      */
     public function build($resource, $method, array $options = [])
     {
-        if (!isset($this->service['resources'][$resource]['methods'][$method])) {
-            throw new \InvalidArgumentException('Provided action ' . $method . ' does not exist.');
+        $root = $this->resourceRoot;
+
+        array_push($root, 'resources', $resource, 'methods', $method);
+
+        $action = $this->service;
+        foreach ($root as $rootItem) {
+            if (!isset($action[$rootItem])) {
+                throw new \InvalidArgumentException('Provided path item ' . $rootItem . ' does not exist.');
+            }
+            $action = $action[$rootItem];
         }
 
-        $action = $this->service['resources'][$resource]['methods'][$method];
         $path = [];
         $query = [];
         $body = [];

--- a/tests/RequestBuilderTest.php
+++ b/tests/RequestBuilderTest.php
@@ -46,6 +46,28 @@ class RequestBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"referenceProp":"reference"}', (string) $request->getBody());
     }
 
+    public function testBuildsNestedRequest()
+    {
+        $builder = new RequestBuilder(
+            __DIR__ . '/fixtures/service-fixture.json',
+            'http://www.example.com/',
+            ['resources', 'projects', 'otherThing']
+        );
+
+        $parameters = [
+            'queryParam' => 'query',
+            'pathParam' => 'path',
+            'referenceProp' => 'reference'
+        ];
+
+        $request = $builder->build('myOtherResource', 'myOtherMethod', $parameters);
+        $uri = $request->getUri();
+
+        $this->assertEquals('/path', $uri->getPath());
+        $this->assertEquals('queryParam=query', $uri->getQuery());
+        $this->assertEquals('{"referenceProp":"reference"}', (string) $request->getBody());
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */

--- a/tests/fixtures/service-fixture.json
+++ b/tests/fixtures/service-fixture.json
@@ -31,6 +31,34 @@
           }
         }
       }
+    },
+    "projects": {
+      "otherThing": {
+        "resources": {
+          "myOtherResource": {
+            "methods": {
+              "myOtherMethod": {
+                "path": "{pathParam}",
+                "httpMethod": "POST",
+                "parameters": {
+                  "queryParam": {
+                    "type": "string",
+                    "location": "query"
+                  },
+                  "pathParam": {
+                    "type": "string",
+                    "required": true,
+                    "location": "path"
+                  }
+                },
+                "request": {
+                  "$ref": "MyReference"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I wanted to get this in front of some eyes.

The basic problem is some schema resources are nested deeper than expected when the RequestBuilder was created.

The basic format we see in schema docs up to now was something like this (at the resources key):

````json
"resources": {
    "bucketAccessControls": {
      "methods": {
        "delete": {
          "id": "storage.bucketAccessControls.delete"
[...]
````

Compare that to the [pubsub discovery document](https://www.googleapis.com/discovery/v1/apis/pubsub/v1/rest):

````json
"resources": {
  "projects": {
   "resources": {
    "topics": {
     "methods": {
      "setIamPolicy": {
       "id": "pubsub.projects.topics.setIamPolicy",
[...]
````

To solve this problem, I added an optional 3rd parameter to the RequestBuilder constructor called `array $resourceRoot`. The resource root will be prepended to the json path that the builder will construct to find the action.

For instance, the constructed path in the first example above would be:

    $this->service['resources'][$resource]['methods'][$method];

In the second example, the constructor would be called with a $resourceRoot of `['resources', 'projects']`. In this case, the constructed path would be:

    $this->service['resources']['projects']['resources'][$resource]['methods'][$method];