### PR TITLE
Add Pubsub client, Topic and Subscription APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 composer.lock
 vendor/
+build/

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,10 @@
     {
       "name": "Dave Supplee",
       "email": "dwsupplee@gmail.com"
+    },
+    {
+      "name": "John Pedrie",
+      "email": "john@pedrie.com"
     }
   ],
   "require": {

--- a/src/Exception/ConflictException.php
+++ b/src/Exception/ConflictException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Exception;
+
+/**
+ * Exception thrown when a request fails due to a conflict.
+ * In REST context, this exception indicates a status code 409.
+ */
+class ConflictException extends GoogleException
+{
+
+}

--- a/src/Exception/GoogleException.php
+++ b/src/Exception/GoogleException.php
@@ -17,10 +17,49 @@
 
 namespace Google\Cloud\Exception;
 
+use Exception;
+
 /**
  * Exception thrown when a request fails.
  */
-class GoogleException extends \Exception
+class GoogleException extends Exception
 {
+    /**
+     * @var Exception
+     */
+    private $serviceException;
 
+    /**
+     * Handle previous exceptions differently here.
+     *
+     * @param  string    $message
+     * @param  int       $code
+     * @param  Exception $serviceException
+     */
+    public function __construct($message, $code = null, Exception $serviceException = null)
+    {
+        $this->serviceException = $serviceException;
+
+        parent::__construct($message, $code);
+    }
+
+    /**
+     * If $serviceException is set, return true.
+     *
+     * @return bool
+     */
+    public function hasServiceException()
+    {
+        return ($this->serviceException);
+    }
+
+    /**
+     * Return the service exception object.
+     *
+     * @return Exception
+     */
+    public function getServiceException()
+    {
+        return $this->serviceException;
+    }
 }

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Exception;
+
+/**
+ * Exception thrown when a resource is not found.
+ */
+class NotFoundException extends GoogleException
+{
+
+}

--- a/src/PubSub/Connection/ConnectionInterface.php
+++ b/src/PubSub/Connection/ConnectionInterface.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub\Connection;
+
+/**
+ * Represents a connection to
+ * [Pub/Sub](https://cloud.google.com/pubsub).
+ */
+interface ConnectionInterface
+{
+    /**
+     * @param  array $args
+     */
+    public function createTopic(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function getTopic(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function deleteTopic(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function listTopics(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function publishMessage(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function listSubscriptionsByTopic(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function createSubscription(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function getSubscription(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function listSubscriptions(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function deleteSubscription(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function modifyPushConfig(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function pull(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function modifyAckDeadline(array $args);
+
+    /**
+     * @param  array $args
+     */
+    public function acknowledge(array $args);
+}

--- a/src/PubSub/Connection/Rest.php
+++ b/src/PubSub/Connection/Rest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub\Connection;
+
+use Google\Cloud\RequestBuilder;
+use Google\Cloud\RequestWrapper;
+use Google\Cloud\RestTrait;
+use Google\Cloud\UriTrait;
+
+/**
+ * Implementation of the
+ * [Google Pub/Sub REST API](https://cloud.google.com/pubsub/reference/rest/).
+ */
+class Rest implements ConnectionInterface
+{
+    use RestTrait;
+    use UriTrait;
+
+    const BASE_URI = 'https://pubsub.googleapis.com/';
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setRequestWrapper(new RequestWrapper($config));
+        $this->setRequestBuilder(new RequestBuilder(
+            __DIR__ . '/ServiceDefinition/pubsub-v1.json',
+            self::BASE_URI,
+            ['resources', 'projects']
+        ));
+    }
+
+    /**
+     * @param array $args
+     */
+    public function createTopic(array $args)
+    {
+        return $this->send('topics', 'create', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function getTopic(array $args)
+    {
+        return $this->send('topics', 'get', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function deleteTopic(array $args)
+    {
+        return $this->send('topics', 'delete', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function listTopics(array $args)
+    {
+        return $this->send('topics', 'list', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function publishMessage(array $args)
+    {
+        return $this->send('topics', 'publish', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function listSubscriptionsByTopic(array $args)
+    {
+        return $this->send('topics.resources.subscriptions', 'list', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function createSubscription(array $args)
+    {
+        return $this->send('subscriptions', 'create', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function getSubscription(array $args)
+    {
+        return $this->send('subscriptions', 'get', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function listSubscriptions(array $args)
+    {
+        return $this->send('subscriptions', 'list', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function deleteSubscription(array $args)
+    {
+        return $this->send('subscriptions', 'delete', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function modifyPushConfig(array $args)
+    {
+        return $this->send('subscriptions', 'modifyPushConfig', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function pull(array $args)
+    {
+        return $this->send('subscriptions', 'pull', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function modifyAckDeadline(array $args)
+    {
+        return $this->send('subscriptions', 'modifyAckDeadline', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function acknowledge(array $args)
+    {
+        return $this->send('subscriptions', 'acknowledge', $args);
+    }
+}

--- a/src/PubSub/Connection/ServiceDefinition/pubsub-v1.json
+++ b/src/PubSub/Connection/ServiceDefinition/pubsub-v1.json
@@ -1,0 +1,1040 @@
+{
+ "kind": "discovery#restDescription",
+ "etag": "\"jQLIOHBVnDZie4rQHGH1WJF-INE/liyzgLngirW3xU7Tt2Pd1AnSK1c\"",
+ "discoveryVersion": "v1",
+ "id": "pubsub:v1",
+ "name": "pubsub",
+ "version": "v1",
+ "revision": "20160317",
+ "title": "Google Cloud Pub/Sub API",
+ "description": "Provides reliable, many-to-many, asynchronous messaging between applications.",
+ "ownerDomain": "google.com",
+ "ownerName": "Google",
+ "icons": {
+  "x16": "http://www.google.com/images/icons/product/search-16.gif",
+  "x32": "http://www.google.com/images/icons/product/search-32.gif"
+ },
+ "documentationLink": "https://cloud.google.com/pubsub/docs",
+ "protocol": "rest",
+ "baseUrl": "https://pubsub.googleapis.com/",
+ "basePath": "",
+ "rootUrl": "https://pubsub.googleapis.com/",
+ "servicePath": "",
+ "batchPath": "batch",
+ "parameters": {
+  "access_token": {
+   "type": "string",
+   "description": "OAuth access token.",
+   "location": "query"
+  },
+  "alt": {
+   "type": "string",
+   "description": "Data format for response.",
+   "default": "json",
+   "enumDescriptions": [
+    "Responses with Content-Type of application/json",
+    "Media download with context-dependent Content-Type",
+    "Responses with Content-Type of application/x-protobuf"
+   ],
+   "location": "query"
+  },
+  "bearer_token": {
+   "type": "string",
+   "description": "OAuth bearer token.",
+   "location": "query"
+  },
+  "callback": {
+   "type": "string",
+   "description": "JSONP",
+   "location": "query"
+  },
+  "fields": {
+   "type": "string",
+   "description": "Selector specifying which fields to include in a partial response.",
+   "location": "query"
+  },
+  "key": {
+   "type": "string",
+   "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+   "location": "query"
+  },
+  "oauth_token": {
+   "type": "string",
+   "description": "OAuth 2.0 token for the current user.",
+   "location": "query"
+  },
+  "pp": {
+   "type": "boolean",
+   "description": "Pretty-print response.",
+   "default": "true",
+   "location": "query"
+  },
+  "prettyPrint": {
+   "type": "boolean",
+   "description": "Returns response with indentations and line breaks.",
+   "default": "true",
+   "location": "query"
+  },
+  "quotaUser": {
+   "type": "string",
+   "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+   "location": "query"
+  },
+  "upload_protocol": {
+   "type": "string",
+   "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+   "location": "query"
+  },
+  "uploadType": {
+   "type": "string",
+   "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+   "location": "query"
+  },
+  "$.xgafv": {
+   "type": "string",
+   "description": "V1 error format.",
+   "enumDescriptions": [
+    "v1 error format",
+    "v2 error format"
+   ],
+   "location": "query"
+  }
+ },
+ "auth": {
+  "oauth2": {
+   "scopes": {
+    "https://www.googleapis.com/auth/cloud-platform": {
+     "description": "View and manage your data across Google Cloud Platform services"
+    },
+    "https://www.googleapis.com/auth/pubsub": {
+     "description": "View and manage Pub/Sub topics and subscriptions"
+    }
+   }
+  }
+ },
+ "schemas": {
+  "SetIamPolicyRequest": {
+   "id": "SetIamPolicyRequest",
+   "type": "object",
+   "description": "Request message for `SetIamPolicy` method.",
+   "properties": {
+    "policy": {
+     "$ref": "Policy",
+     "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Cloud Platform services (such as Projects) might reject them."
+    }
+   }
+  },
+  "Policy": {
+   "id": "Policy",
+   "type": "object",
+   "description": "Defines an Identity and Access Management (IAM) policy. It is used to specify access control policies for Cloud Platform resources. A `Policy` consists of a list of `bindings`. A `Binding` binds a list of `members` to a `role`, where the members can be user accounts, Google groups, Google domains, and service accounts. A `role` is a named list of permissions defined by IAM. **Example** { \"bindings\": [ { \"role\": \"roles/owner\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-other-app@appspot.gserviceaccount.com\", ] }, { \"role\": \"roles/viewer\", \"members\": [\"user:sean@example.com\"] } ] } For a description of IAM and its features, see the [IAM developer's guide](https://cloud.google.com/iam).",
+   "properties": {
+    "version": {
+     "type": "integer",
+     "description": "Version of the `Policy`. The default version is 0.",
+     "format": "int32"
+    },
+    "bindings": {
+     "type": "array",
+     "description": "Associates a list of `members` to a `role`. Multiple `bindings` must not be specified for the same `role`. `bindings` with no members will result in an error.",
+     "items": {
+      "$ref": "Binding"
+     }
+    },
+    "etag": {
+     "type": "string",
+     "description": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. If no `etag` is provided in the call to `setIamPolicy`, then the existing policy is overwritten blindly.",
+     "format": "byte"
+    }
+   }
+  },
+  "Binding": {
+   "id": "Binding",
+   "type": "object",
+   "description": "Associates `members` with a `role`.",
+   "properties": {
+    "role": {
+     "type": "string",
+     "description": "Role that is assigned to `members`. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. Required"
+    },
+    "members": {
+     "type": "array",
+     "description": "Specifies the identities requesting access for a Cloud Platform resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@gmail.com` or `joe@example.com`. * `serviceAccount:{emailid}`: An email address that represents a service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: A Google Apps domain name that represents all the users of that domain. For example, `google.com` or `example.com`.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "TestIamPermissionsRequest": {
+   "id": "TestIamPermissionsRequest",
+   "type": "object",
+   "description": "Request message for `TestIamPermissions` method.",
+   "properties": {
+    "permissions": {
+     "type": "array",
+     "description": "The set of permissions to check for the `resource`. Permissions with wildcards (such as '*' or 'storage.*') are not allowed. For more information see IAM Overview.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "TestIamPermissionsResponse": {
+   "id": "TestIamPermissionsResponse",
+   "type": "object",
+   "description": "Response message for `TestIamPermissions` method.",
+   "properties": {
+    "permissions": {
+     "type": "array",
+     "description": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "Topic": {
+   "id": "Topic",
+   "type": "object",
+   "description": "A topic resource.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "The name of the topic. It must have the format `\"projects/{project}/topics/{topic}\"`. `{topic}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `\"goog\"`."
+    }
+   }
+  },
+  "PublishRequest": {
+   "id": "PublishRequest",
+   "type": "object",
+   "description": "Request for the Publish method.",
+   "properties": {
+    "messages": {
+     "type": "array",
+     "description": "The messages to publish.",
+     "items": {
+      "$ref": "PubsubMessage"
+     }
+    }
+   }
+  },
+  "PubsubMessage": {
+   "id": "PubsubMessage",
+   "type": "object",
+   "description": "A message data and its attributes. The message payload must not be empty; it must contain either a non-empty data field, or at least one attribute.",
+   "properties": {
+    "data": {
+     "type": "string",
+     "description": "The message payload. For JSON requests, the value of this field must be base64-encoded.",
+     "format": "byte"
+    },
+    "attributes": {
+     "type": "object",
+     "description": "Optional attributes for this message.",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "messageId": {
+     "type": "string",
+     "description": "ID of this message, assigned by the server when the message is published. Guaranteed to be unique within the topic. This value may be read by a subscriber that receives a `PubsubMessage` via a `Pull` call or a push delivery. It must not be populated by the publisher in a `Publish` call."
+    },
+    "publishTime": {
+     "type": "string",
+     "description": "The time at which the message was published, populated by the server when it receives the `Publish` call. It must not be populated by the publisher in a `Publish` call."
+    }
+   }
+  },
+  "PublishResponse": {
+   "id": "PublishResponse",
+   "type": "object",
+   "description": "Response for the `Publish` method.",
+   "properties": {
+    "messageIds": {
+     "type": "array",
+     "description": "The server-assigned ID of each published message, in the same order as the messages in the request. IDs are guaranteed to be unique within the topic.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "ListTopicsResponse": {
+   "id": "ListTopicsResponse",
+   "type": "object",
+   "description": "Response for the `ListTopics` method.",
+   "properties": {
+    "topics": {
+     "type": "array",
+     "description": "The resulting topics.",
+     "items": {
+      "$ref": "Topic"
+     }
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "If not empty, indicates that there may be more topics that match the request; this value should be passed in a new `ListTopicsRequest`."
+    }
+   }
+  },
+  "ListTopicSubscriptionsResponse": {
+   "id": "ListTopicSubscriptionsResponse",
+   "type": "object",
+   "description": "Response for the `ListTopicSubscriptions` method.",
+   "properties": {
+    "subscriptions": {
+     "type": "array",
+     "description": "The names of the subscriptions that match the request.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "If not empty, indicates that there may be more subscriptions that match the request; this value should be passed in a new `ListTopicSubscriptionsRequest` to get more subscriptions."
+    }
+   }
+  },
+  "Empty": {
+   "id": "Empty",
+   "type": "object",
+   "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); } The JSON representation for `Empty` is empty JSON object `{}`."
+  },
+  "Subscription": {
+   "id": "Subscription",
+   "type": "object",
+   "description": "A subscription resource.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "The name of the subscription. It must have the format `\"projects/{project}/subscriptions/{subscription}\"`. `{subscription}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `\"goog\"`."
+    },
+    "topic": {
+     "type": "string",
+     "description": "The name of the topic from which this subscription is receiving messages. The value of this field will be `_deleted-topic_` if the topic has been deleted."
+    },
+    "pushConfig": {
+     "$ref": "PushConfig",
+     "description": "If push delivery is used with this subscription, this field is used to configure it. An empty `pushConfig` signifies that the subscriber will pull and ack messages using API methods."
+    },
+    "ackDeadlineSeconds": {
+     "type": "integer",
+     "description": "This value is the maximum time after a subscriber receives a message before the subscriber should acknowledge the message. After message delivery but before the ack deadline expires and before the message is acknowledged, it is an outstanding message and will not be delivered again during that time (on a best-effort basis). For pull subscriptions, this value is used as the initial value for the ack deadline. To override this value for a given message, call `ModifyAckDeadline` with the corresponding `ack_id` if using pull. For push delivery, this value is also used to set the request timeout for the call to the push endpoint. If the subscriber never acknowledges the message, the Pub/Sub system will eventually redeliver the message. If this parameter is not set, the default value of 10 seconds is used.",
+     "format": "int32"
+    }
+   }
+  },
+  "PushConfig": {
+   "id": "PushConfig",
+   "type": "object",
+   "description": "Configuration for a push delivery endpoint.",
+   "properties": {
+    "pushEndpoint": {
+     "type": "string",
+     "description": "A URL locating the endpoint to which messages should be pushed. For example, a Webhook endpoint might use \"https://example.com/push\"."
+    },
+    "attributes": {
+     "type": "object",
+     "description": "Endpoint configuration attributes. Every endpoint has a set of API supported attributes that can be used to control different aspects of the message delivery. The currently supported attribute is `x-goog-version`, which you can use to change the format of the push message. This attribute indicates the version of the data expected by the endpoint. This controls the shape of the envelope (i.e. its fields and metadata). The endpoint version is based on the version of the Pub/Sub API. If not present during the `CreateSubscription` call, it will default to the version of the API used to make such call. If not present during a `ModifyPushConfig` call, its value will not be changed. `GetSubscription` calls will always return a valid version, even if the subscription was created without this attribute. The possible values for this attribute are: * `v1beta1`: uses the push format defined in the v1beta1 Pub/Sub API. * `v1` or `v1beta2`: uses the push format defined in the v1 Pub/Sub API.",
+     "additionalProperties": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "ListSubscriptionsResponse": {
+   "id": "ListSubscriptionsResponse",
+   "type": "object",
+   "description": "Response for the `ListSubscriptions` method.",
+   "properties": {
+    "subscriptions": {
+     "type": "array",
+     "description": "The subscriptions that match the request.",
+     "items": {
+      "$ref": "Subscription"
+     }
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "If not empty, indicates that there may be more subscriptions that match the request; this value should be passed in a new `ListSubscriptionsRequest` to get more subscriptions."
+    }
+   }
+  },
+  "ModifyAckDeadlineRequest": {
+   "id": "ModifyAckDeadlineRequest",
+   "type": "object",
+   "description": "Request for the ModifyAckDeadline method.",
+   "properties": {
+    "ackIds": {
+     "type": "array",
+     "description": "List of acknowledgment IDs.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "ackDeadlineSeconds": {
+     "type": "integer",
+     "description": "The new ack deadline with respect to the time this request was sent to the Pub/Sub system. Must be \u003e= 0. For example, if the value is 10, the new ack deadline will expire 10 seconds after the `ModifyAckDeadline` call was made. Specifying zero may immediately make the message available for another pull request.",
+     "format": "int32"
+    }
+   }
+  },
+  "AcknowledgeRequest": {
+   "id": "AcknowledgeRequest",
+   "type": "object",
+   "description": "Request for the Acknowledge method.",
+   "properties": {
+    "ackIds": {
+     "type": "array",
+     "description": "The acknowledgment ID for the messages being acknowledged that was returned by the Pub/Sub system in the `Pull` response. Must not be empty.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "PullRequest": {
+   "id": "PullRequest",
+   "type": "object",
+   "description": "Request for the `Pull` method.",
+   "properties": {
+    "returnImmediately": {
+     "type": "boolean",
+     "description": "If this is specified as true the system will respond immediately even if it is not able to return a message in the `Pull` response. Otherwise the system is allowed to wait until at least one message is available rather than returning no messages. The client may cancel the request if it does not wish to wait any longer for the response."
+    },
+    "maxMessages": {
+     "type": "integer",
+     "description": "The maximum number of messages returned for this request. The Pub/Sub system may return fewer than the number specified.",
+     "format": "int32"
+    }
+   }
+  },
+  "PullResponse": {
+   "id": "PullResponse",
+   "type": "object",
+   "description": "Response for the `Pull` method.",
+   "properties": {
+    "receivedMessages": {
+     "type": "array",
+     "description": "Received Pub/Sub messages. The Pub/Sub system will return zero messages if there are no more available in the backlog. The Pub/Sub system may return fewer than the `maxMessages` requested even if there are more messages available in the backlog.",
+     "items": {
+      "$ref": "ReceivedMessage"
+     }
+    }
+   }
+  },
+  "ReceivedMessage": {
+   "id": "ReceivedMessage",
+   "type": "object",
+   "description": "A message and its corresponding acknowledgment ID.",
+   "properties": {
+    "ackId": {
+     "type": "string",
+     "description": "This ID can be used to acknowledge the received message."
+    },
+    "message": {
+     "$ref": "PubsubMessage",
+     "description": "The message."
+    }
+   }
+  },
+  "ModifyPushConfigRequest": {
+   "id": "ModifyPushConfigRequest",
+   "type": "object",
+   "description": "Request for the ModifyPushConfig method.",
+   "properties": {
+    "pushConfig": {
+     "$ref": "PushConfig",
+     "description": "The push configuration for future deliveries. An empty `pushConfig` indicates that the Pub/Sub system should stop pushing messages from the given subscription and allow messages to be pulled and acknowledged - effectively pausing the subscription if `Pull` is not called."
+    }
+   }
+  }
+ },
+ "resources": {
+  "projects": {
+   "resources": {
+    "topics": {
+     "methods": {
+      "setIamPolicy": {
+       "id": "pubsub.projects.topics.setIamPolicy",
+       "path": "v1/{+resource}:setIamPolicy",
+       "httpMethod": "POST",
+       "description": "Sets the access control policy on the specified resource. Replaces any existing policy.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `setIamPolicy` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/topics/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "request": {
+        "$ref": "SetIamPolicyRequest"
+       },
+       "response": {
+        "$ref": "Policy"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "getIamPolicy": {
+       "id": "pubsub.projects.topics.getIamPolicy",
+       "path": "v1/{+resource}:getIamPolicy",
+       "httpMethod": "GET",
+       "description": "Gets the access control policy for a `resource`. Returns an empty policy if the resource exists and does not have a policy set.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `getIamPolicy` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/topics/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "response": {
+        "$ref": "Policy"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "testIamPermissions": {
+       "id": "pubsub.projects.topics.testIamPermissions",
+       "path": "v1/{+resource}:testIamPermissions",
+       "httpMethod": "POST",
+       "description": "Returns permissions that a caller has on the specified resource.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy detail is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `testIamPermissions` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/topics/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "request": {
+        "$ref": "TestIamPermissionsRequest"
+       },
+       "response": {
+        "$ref": "TestIamPermissionsResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "create": {
+       "id": "pubsub.projects.topics.create",
+       "path": "v1/{+name}",
+       "httpMethod": "PUT",
+       "description": "Creates the given topic with the given name.",
+       "parameters": {
+        "name": {
+         "type": "string",
+         "description": "The name of the topic. It must have the format `\"projects/{project}/topics/{topic}\"`. `{topic}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `\"goog\"`.",
+         "required": true,
+         "pattern": "^projects/[^/]*/topics/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "name"
+       ],
+       "request": {
+        "$ref": "Topic"
+       },
+       "response": {
+        "$ref": "Topic"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "publish": {
+       "id": "pubsub.projects.topics.publish",
+       "path": "v1/{+topic}:publish",
+       "httpMethod": "POST",
+       "description": "Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic does not exist. The message payload must not be empty; it must contain either a non-empty data field, or at least one attribute.",
+       "parameters": {
+        "topic": {
+         "type": "string",
+         "description": "The messages in the request will be published on this topic.",
+         "required": true,
+         "pattern": "^projects/[^/]*/topics/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "topic"
+       ],
+       "request": {
+        "$ref": "PublishRequest"
+       },
+       "response": {
+        "$ref": "PublishResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "get": {
+       "id": "pubsub.projects.topics.get",
+       "path": "v1/{+topic}",
+       "httpMethod": "GET",
+       "description": "Gets the configuration of a topic.",
+       "parameters": {
+        "topic": {
+         "type": "string",
+         "description": "The name of the topic to get.",
+         "required": true,
+         "pattern": "^projects/[^/]*/topics/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "topic"
+       ],
+       "response": {
+        "$ref": "Topic"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "list": {
+       "id": "pubsub.projects.topics.list",
+       "path": "v1/{+project}/topics",
+       "httpMethod": "GET",
+       "description": "Lists matching topics.",
+       "parameters": {
+        "project": {
+         "type": "string",
+         "description": "The name of the cloud project that topics belong to.",
+         "required": true,
+         "pattern": "^projects/[^/]*$",
+         "location": "path"
+        },
+        "pageSize": {
+         "type": "integer",
+         "description": "Maximum number of topics to return.",
+         "format": "int32",
+         "location": "query"
+        },
+        "pageToken": {
+         "type": "string",
+         "description": "The value returned by the last `ListTopicsResponse`; indicates that this is a continuation of a prior `ListTopics` call, and that the system should return the next page of data.",
+         "location": "query"
+        }
+       },
+       "parameterOrder": [
+        "project"
+       ],
+       "response": {
+        "$ref": "ListTopicsResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "delete": {
+       "id": "pubsub.projects.topics.delete",
+       "path": "v1/{+topic}",
+       "httpMethod": "DELETE",
+       "description": "Deletes the topic with the given name. Returns `NOT_FOUND` if the topic does not exist. After a topic is deleted, a new topic may be created with the same name; this is an entirely new topic with none of the old configuration or subscriptions. Existing subscriptions to this topic are not deleted, but their `topic` field is set to `_deleted-topic_`.",
+       "parameters": {
+        "topic": {
+         "type": "string",
+         "description": "Name of the topic to delete.",
+         "required": true,
+         "pattern": "^projects/[^/]*/topics/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "topic"
+       ],
+       "response": {
+        "$ref": "Empty"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      }
+     },
+     "resources": {
+      "subscriptions": {
+       "methods": {
+        "list": {
+         "id": "pubsub.projects.topics.subscriptions.list",
+         "path": "v1/{+topic}/subscriptions",
+         "httpMethod": "GET",
+         "description": "Lists the name of the subscriptions for this topic.",
+         "parameters": {
+          "topic": {
+           "type": "string",
+           "description": "The name of the topic that subscriptions are attached to.",
+           "required": true,
+           "pattern": "^projects/[^/]*/topics/[^/]*$",
+           "location": "path"
+          },
+          "pageSize": {
+           "type": "integer",
+           "description": "Maximum number of subscription names to return.",
+           "format": "int32",
+           "location": "query"
+          },
+          "pageToken": {
+           "type": "string",
+           "description": "The value returned by the last `ListTopicSubscriptionsResponse`; indicates that this is a continuation of a prior `ListTopicSubscriptions` call, and that the system should return the next page of data.",
+           "location": "query"
+          }
+         },
+         "parameterOrder": [
+          "topic"
+         ],
+         "response": {
+          "$ref": "ListTopicSubscriptionsResponse"
+         },
+         "scopes": [
+          "https://www.googleapis.com/auth/cloud-platform",
+          "https://www.googleapis.com/auth/pubsub"
+         ]
+        }
+       }
+      }
+     }
+    },
+    "subscriptions": {
+     "methods": {
+      "setIamPolicy": {
+       "id": "pubsub.projects.subscriptions.setIamPolicy",
+       "path": "v1/{+resource}:setIamPolicy",
+       "httpMethod": "POST",
+       "description": "Sets the access control policy on the specified resource. Replaces any existing policy.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `setIamPolicy` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "request": {
+        "$ref": "SetIamPolicyRequest"
+       },
+       "response": {
+        "$ref": "Policy"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "getIamPolicy": {
+       "id": "pubsub.projects.subscriptions.getIamPolicy",
+       "path": "v1/{+resource}:getIamPolicy",
+       "httpMethod": "GET",
+       "description": "Gets the access control policy for a `resource`. Returns an empty policy if the resource exists and does not have a policy set.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `getIamPolicy` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "response": {
+        "$ref": "Policy"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "testIamPermissions": {
+       "id": "pubsub.projects.subscriptions.testIamPermissions",
+       "path": "v1/{+resource}:testIamPermissions",
+       "httpMethod": "POST",
+       "description": "Returns permissions that a caller has on the specified resource.",
+       "parameters": {
+        "resource": {
+         "type": "string",
+         "description": "REQUIRED: The resource for which the policy detail is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `testIamPermissions` documentation.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "resource"
+       ],
+       "request": {
+        "$ref": "TestIamPermissionsRequest"
+       },
+       "response": {
+        "$ref": "TestIamPermissionsResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "create": {
+       "id": "pubsub.projects.subscriptions.create",
+       "path": "v1/{+name}",
+       "httpMethod": "PUT",
+       "description": "Creates a subscription to a given topic. If the subscription already exists, returns `ALREADY_EXISTS`. If the corresponding topic doesn't exist, returns `NOT_FOUND`. If the name is not provided in the request, the server will assign a random name for this subscription on the same project as the topic.",
+       "parameters": {
+        "name": {
+         "type": "string",
+         "description": "The name of the subscription. It must have the format `\"projects/{project}/subscriptions/{subscription}\"`. `{subscription}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `\"goog\"`.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "name"
+       ],
+       "request": {
+        "$ref": "Subscription"
+       },
+       "response": {
+        "$ref": "Subscription"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "get": {
+       "id": "pubsub.projects.subscriptions.get",
+       "path": "v1/{+subscription}",
+       "httpMethod": "GET",
+       "description": "Gets the configuration details of a subscription.",
+       "parameters": {
+        "subscription": {
+         "type": "string",
+         "description": "The name of the subscription to get.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "subscription"
+       ],
+       "response": {
+        "$ref": "Subscription"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "list": {
+       "id": "pubsub.projects.subscriptions.list",
+       "path": "v1/{+project}/subscriptions",
+       "httpMethod": "GET",
+       "description": "Lists matching subscriptions.",
+       "parameters": {
+        "project": {
+         "type": "string",
+         "description": "The name of the cloud project that subscriptions belong to.",
+         "required": true,
+         "pattern": "^projects/[^/]*$",
+         "location": "path"
+        },
+        "pageSize": {
+         "type": "integer",
+         "description": "Maximum number of subscriptions to return.",
+         "format": "int32",
+         "location": "query"
+        },
+        "pageToken": {
+         "type": "string",
+         "description": "The value returned by the last `ListSubscriptionsResponse`; indicates that this is a continuation of a prior `ListSubscriptions` call, and that the system should return the next page of data.",
+         "location": "query"
+        }
+       },
+       "parameterOrder": [
+        "project"
+       ],
+       "response": {
+        "$ref": "ListSubscriptionsResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "delete": {
+       "id": "pubsub.projects.subscriptions.delete",
+       "path": "v1/{+subscription}",
+       "httpMethod": "DELETE",
+       "description": "Deletes an existing subscription. All pending messages in the subscription are immediately dropped. Calls to `Pull` after deletion will return `NOT_FOUND`. After a subscription is deleted, a new one may be created with the same name, but the new one has no association with the old subscription, or its topic unless the same topic is specified.",
+       "parameters": {
+        "subscription": {
+         "type": "string",
+         "description": "The subscription to delete.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "subscription"
+       ],
+       "response": {
+        "$ref": "Empty"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "modifyAckDeadline": {
+       "id": "pubsub.projects.subscriptions.modifyAckDeadline",
+       "path": "v1/{+subscription}:modifyAckDeadline",
+       "httpMethod": "POST",
+       "description": "Modifies the ack deadline for a specific message. This method is useful to indicate that more time is needed to process a message by the subscriber, or to make the message available for redelivery if the processing was interrupted.",
+       "parameters": {
+        "subscription": {
+         "type": "string",
+         "description": "The name of the subscription.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "subscription"
+       ],
+       "request": {
+        "$ref": "ModifyAckDeadlineRequest"
+       },
+       "response": {
+        "$ref": "Empty"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "acknowledge": {
+       "id": "pubsub.projects.subscriptions.acknowledge",
+       "path": "v1/{+subscription}:acknowledge",
+       "httpMethod": "POST",
+       "description": "Acknowledges the messages associated with the `ack_ids` in the `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages from the subscription. Acknowledging a message whose ack deadline has expired may succeed, but such a message may be redelivered later. Acknowledging a message more than once will not result in an error.",
+       "parameters": {
+        "subscription": {
+         "type": "string",
+         "description": "The subscription whose message is being acknowledged.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "subscription"
+       ],
+       "request": {
+        "$ref": "AcknowledgeRequest"
+       },
+       "response": {
+        "$ref": "Empty"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "pull": {
+       "id": "pubsub.projects.subscriptions.pull",
+       "path": "v1/{+subscription}:pull",
+       "httpMethod": "POST",
+       "description": "Pulls messages from the server. Returns an empty list if there are no messages available in the backlog. The server may return `UNAVAILABLE` if there are too many concurrent pull requests pending for the given subscription.",
+       "parameters": {
+        "subscription": {
+         "type": "string",
+         "description": "The subscription from which messages should be pulled.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "subscription"
+       ],
+       "request": {
+        "$ref": "PullRequest"
+       },
+       "response": {
+        "$ref": "PullResponse"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      },
+      "modifyPushConfig": {
+       "id": "pubsub.projects.subscriptions.modifyPushConfig",
+       "path": "v1/{+subscription}:modifyPushConfig",
+       "httpMethod": "POST",
+       "description": "Modifies the `PushConfig` for a specified subscription. This may be used to change a push subscription to a pull one (signified by an empty `PushConfig`) or vice versa, or change the endpoint URL and other attributes of a push subscription. Messages will accumulate for delivery continuously through the call regardless of changes to the `PushConfig`.",
+       "parameters": {
+        "subscription": {
+         "type": "string",
+         "description": "The name of the subscription.",
+         "required": true,
+         "pattern": "^projects/[^/]*/subscriptions/[^/]*$",
+         "location": "path"
+        }
+       },
+       "parameterOrder": [
+        "subscription"
+       ],
+       "request": {
+        "$ref": "ModifyPushConfigRequest"
+       },
+       "response": {
+        "$ref": "Empty"
+       },
+       "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/pubsub"
+       ]
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/src/PubSub/PubSubClient.php
+++ b/src/PubSub/PubSubClient.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub;
+
+use Google\Cloud\PubSub\Connection\Rest;
+use InvalidArgumentException;
+
+/**
+ * Google Cloud Pub/Sub client. Allows you to send and receive
+ * messages between independent applications. Find more information at
+ * [Google Cloud Pub/Sub docs](https://cloud.google.com/pubsub/docs/).
+ */
+class PubSubClient
+{
+    use ResourceNameTrait;
+
+    const FULL_CONTROL_SCOPE = 'https://www.googleapis.com/auth/pubsub';
+
+    /**
+     * @var string The project ID created in the Google Developers Console.
+     */
+    private $projectId;
+
+    /**
+     * Create a PubSub client.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *     'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * // The PubSub client can also be instantianted directly.
+     * use Google\Cloud\PubSub\PubSubClient;
+     *
+     * $pubsub = new PubSubClient([
+     *     'projectId' => 'my-awesome-project'
+     * ]);
+     * ```
+     *
+     * @param array $config {
+     *     Configuration Options.
+     *
+     *     @type string $projectId The project ID from the Google Developer's
+     *           Console.
+     *     @type callable $authHttpHandler A handler used to deliver Psr7
+     *           requests specifically for authentication.
+     *     @type callable $httpHandler A handler used to deliver Psr7 requests.
+     *     @type string $keyFile The contents of the service account
+     *           credentials .json file retrieved from the Google Developers
+     *           Console.
+     *     @type string $keyFilePath The full path to your service account
+     *           credentials .json file retrieved from the Google Developers
+     *           Console.
+     *     @type int $retries Number of retries for a failed request. Defaults
+     *           to 3.
+     *     @type array $scopes Scopes to be used for the request.
+     * }
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(array $config = [])
+    {
+        if (!isset($config['projectId'])) {
+            throw new InvalidArgumentException('A projectId is required.');
+        }
+
+        if (!isset($config['scopes'])) {
+            $config['scopes'] = [self::FULL_CONTROL_SCOPE];
+        }
+
+        $this->connection = new Rest($config);
+        $this->projectId = $config['projectId'];
+    }
+
+    /**
+     * Create a topic.
+     *
+     * Unlike {@see PubSubClient::topic()}, this method will send an API call to
+     * create the topic. If the topic already exists, an exception will be
+     * thrown. When in doubt, use {@see PubSubClient::topic()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\PubSub\StorageClient;
+     *
+     * $pubsub = new PubSubClient([
+     *     'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $topic = $pubsub->createTopic('my-new-topic');
+     * echo $topic->info()['name']; // `projects/my-awesome-project/topics/my-new-topic`
+     * ```
+     *
+     * @param  string $name    The topic name
+     * @param  array  $options Configuration Options
+     * @return Topic
+     */
+    public function createTopic($name, array $options = [])
+    {
+        $topic = $this->topic($name);
+        $topic->create($options);
+
+        return $topic;
+    }
+
+    /**
+     * Get a topic by its name.
+     *
+     * No API requests are made by this method. If you want to create a new
+     * topic, use {@see Topic::createTopic()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\PubSub\StorageClient;
+     *
+     * $pubsub = new PubSubClient([
+     *     'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * // No API request yet!
+     * $topic = $pubsub->topic('my-new-topic');
+     *
+     * // This will execute an API call.
+     * echo $topic->info()['name']; // `projects/my-awesome-project/topics/my-new-topic`
+     * ```
+     *
+     * @param  string $name The topic name
+     * @param  array  $info Information about the topic. Used internally to
+     *         populate topic objects with an API result. Should be
+     *         an instance of[https://cloud.google.com/pubsub/reference/rest/v1/projects.topics#Topic](Topic).
+     * @return Topic
+     */
+    public function topic($name, array $info = null)
+    {
+        return new Topic($this->connection, $name, $this->projectId, $info);
+    }
+
+    /**
+     * Get a list of the topics registered to your project.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\PubSub\StorageClient;
+     *
+     * $pubsub = new PubSubClient([
+     *     'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $topics = $pubsub->topics();
+     * foreach ($topics as $topic) {
+     *      $info = $topic->info();
+     *      echo $info['name']; // `projects/my-awesome-project/topics/<topic-name>`
+     * }
+     * ```
+     *
+     * @param  array     $options {
+     *     Configuration Options
+     *
+     *     @type int $pageSize Maximum number of results to return per
+     *           request.
+     * }
+     * @return Generator
+     */
+    public function topics(array $options = [])
+    {
+        $options['pageToken'] = null;
+
+        do {
+            $response = $this->connection->listTopics($options + [
+                'project' => $this->formatName('project', $this->projectId)
+            ]);
+
+            foreach ($response['topics'] as $topic) {
+                yield $this->topic($topic['name'], $topic);
+            }
+
+            // If there's a page token, we'll request the next page.
+            $options['pageToken'] = isset($response['nextPageToken'])
+                ? $response['nextPageToken']
+                : null;
+        } while ($options['pageToken']);
+    }
+
+    /**
+     * Create a Subscription. If the subscription does not exist, it will be
+     * created.
+     *
+     * Use {@see PubSubClient::subscription()} to create a subscription object
+     * without any API requests. If the topic already exists, an exception will
+     * be thrown. When in doubt, use {@see PubSubClient::subscription()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $pubsub = new PubSubClient([
+     *     'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * // Create a subscription. If it doesn't exist in the API, it will be created.
+     * $subscription = $pubsub->subscribe('my-new-subscription', 'my-topic-name');
+     * ```
+     *
+     * @param  string       $name      A subscription name
+     * @param  string       $topicName The topic to which the new subscription will be subscribed.
+     * @param  array        $options Please see {@see Subscription::create()} for configuration details.
+     * @return Subscription
+     */
+    public function subscribe($name, $topicName, array $options = [])
+    {
+        $subscription = $this->subscription($name, $topicName);
+        $subscription->create($options);
+
+        return $subscription;
+    }
+
+    /**
+     * Get a single subscription by its name.
+     *
+     * This method will NOT perform any API calls. If you wish to create a new
+     * subscription, use {@see PubSubClient::subscribe()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\PubSub\StorageClient;
+     *
+     * $pubsub = new PubSubClient([
+     *     'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * // Create a subscription object. You should check if it exists before
+     * // using it, unless you're sure it's there.
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * ```
+     *
+     * @param  string       $name      The subscription name
+     * @param  string       $topicName The topic name
+     * @param  array        $info      Information about the subscription. Used
+     *         to populate subscriptons with an api result. Should be an instance
+     *         of [https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions#Subscription](Subscription).
+     * @return Subscription
+     */
+    public function subscription(
+        $name,
+        $topicName = null,
+        array $info = null
+    ) {
+        return new Subscription(
+            $this->connection,
+            $name,
+            $topicName,
+            $this->projectId,
+            $info
+        );
+    }
+
+    /**
+     * Get a list of the subscriptions registered to all of your project's
+     * topics.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\PubSub\StorageClient;
+     *
+     * $pubsub = new PubSubClient([
+     *     'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $subscriptions = $pubsub->subscriptions();
+     * foreach ($subscriptions as $subscription) {
+     *      $info = $subscription->info();
+     *      echo $info['name']; // `projects/my-awesome-project/subscriptions/<subscription-name>`
+     * }
+     * ```
+     *
+     * @param  array $options {
+     *     Configuration Options
+     *
+     *     @type int $pageSize Maximum number of results to return per
+     *           request.
+     * }
+     * @return \Generator
+     */
+    public function subscriptions(array $options = [])
+    {
+        $options['pageToken'] = null;
+
+        do {
+            $response = $this->connection->listSubscriptions($options + [
+                'project' => $this->formatName('project', $this->projectId)
+            ]);
+
+            foreach ($response['subscriptions'] as $subscription) {
+                yield $this->subscription(
+                    $subscription['name'],
+                    $subscription['topic'],
+                    $subscription
+                );
+            }
+
+            // If there's a page token, we'll request the next page.
+            $options['pageToken'] = isset($response['nextPageToken'])
+                ? $response['nextPageToken']
+                : null;
+        } while ($options['pageToken']);
+    }
+}

--- a/src/PubSub/ResourceNameTrait.php
+++ b/src/PubSub/ResourceNameTrait.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub;
+
+use InvalidArgumentException;
+
+trait ResourceNameTrait
+{
+    /**
+     * @var array
+     */
+    private $templates = [
+        'project' => 'projects/%1$s',
+        'topic' => 'projects/%2$s/topics/%1$s',
+        'subscription' => 'projects/%2$s/subscriptions/%1$s'
+    ];
+
+    /**
+     * @var array
+     */
+    private $regexes = [
+        'project' => '/^projects\/([^\/]*)$/',
+        'topic' => '/projects\/[^\/]*\/topics\/(.*)/',
+        'subscription' => '/projects\/[^\/]*\/subscriptions\/(.*)/'
+    ];
+
+    /**
+     * Convert a fully-qualified name into a simple name.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     * $topic = $pubsub->topic('projects/my-awesome-project/topics/my-topic-name');
+     * echo $topic->pluckName('topic', $name); // `my-topic-name`
+     * ```
+     *
+     * @param  string $name
+     * @return string
+     * @throws InvalidArgumentException
+     */
+    public function pluckName($type, $name)
+    {
+        if (!isset($this->regexes[$type])) {
+            throw new InvalidArgumentException(sprintf(
+                'Regex `%s` is not defined',
+                $type
+            ));
+        }
+
+        $matches = [];
+        $res = preg_match($this->regexes[$type], $name, $matches);
+        return ($res === 1) ? $matches[1] : null;
+    }
+
+    /**
+     * Convert a simple name into the fully-qualified name required by
+     * the API.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     * $topic = $pubsub->topic('my-topic-name');
+     * echo $topic->formatName('topic', $name); // `projects/my-awesome-project/topics/my-topic-name`
+     * ```
+     *
+     * @param  string $type
+     * @param  string $name
+     * @param  string $projectId
+     * @return string
+     * @throws InvalidArgumentException
+     */
+    public function formatName($type, $name, $projectId = null)
+    {
+        if (!isset($this->templates[$type])) {
+            throw new InvalidArgumentException(sprintf(
+                'Template `%s` is not defined',
+                $type
+            ));
+        }
+
+        return vsprintf($this->templates[$type], [$name, $projectId]);
+    }
+
+    /**
+     * Check if a name of a give type is a fully-qualified resource name.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     * $topic = $pubsub->topic('my-topic-name');
+     * if ($topic->isFullyQualifiedName('project', 'projects/my-awesome-project/topics/my-topic-name')) {
+     *      // do stuff
+     * }
+     * ```
+     *
+     * @param  string $type
+     * @param  string $name
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    public function isFullyQualifiedName($type, $name)
+    {
+        if (!isset($this->regexes[$type])) {
+            throw new InvalidArgumentException(sprintf(
+                'Regex `%s` is not defined',
+                $type
+            ));
+        }
+        return (preg_match($this->regexes[$type], $name) === 1);
+    }
+}

--- a/src/PubSub/Subscription.php
+++ b/src/PubSub/Subscription.php
@@ -1,0 +1,604 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub;
+
+use Google\Cloud\Exception\NotFoundException;
+use Google\Cloud\PubSub\Connection\ConnectionInterface;
+use InvalidArgumentException;
+
+/**
+ * A named resource representing the stream of messages from a single, specific
+ * topic, to be delivered to the subscribing application.
+ */
+class Subscription
+{
+    use ResourceNameTrait;
+
+    const MAX_MESSAGES = 1000;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $topicName;
+
+    /**
+     * @var string
+     */
+    private $projectId;
+
+    /**
+     * @var ConnectionInterface
+     */
+    private $connection;
+
+    /**
+     * @var array
+     */
+    private $info;
+
+    /**
+     * Create a Subscription.
+     *
+     * The idiomatic way to use this class is through the PubSubClient or Topic,
+     * but you can instantiate it directly as well.
+     *
+     * Example:
+     * ```php
+     * // Create subscription through a topic
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     *
+     * $subscription = $topic->subscription('my-new-subscription');
+     *
+     * // Create subscription through PubSubClient
+     *
+     * use Google\Cloud\PubSub\PubSubClient;
+     *
+     * $pubsub = new PubSubClient([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $subscription = $pubsub->subscription(
+     *      'my-new-subscription',
+     *      'my-topic-name'
+     * );
+     *
+     * // Create subscription directly
+     * use Google\Cloud\Pubsub\Subscription;
+     *
+     * $subscription = new Subscription(
+     *      $connection
+     *      'my-new-subscription',
+     *      'my-topic-name',
+     *      'my-awesome-project'
+     * );
+     * ```
+     *
+     * @param  ConnectionInterface The service connection object
+     * @param  string $name        The subscription name
+     * @param  string $topicName   The topic name the subscription is attached to
+     * @param  string $projectId   The current project
+     * @param  array  $info        Subscription info. Used to pre-populate the object.
+     */
+    public function __construct(
+        ConnectionInterface $connection,
+        $name,
+        $topicName,
+        $projectId,
+        array $info = null
+    ) {
+        $this->connection = $connection;
+        $this->projectId = $projectId;
+        $this->info = $info;
+
+        // Accept either a simple name or a fully-qualified name.
+        if ($this->isFullyQualifiedName('subscription', $name)) {
+            $this->name = $name;
+        } else {
+            $this->name = $this->formatName('subscription', $name, $projectId);
+        }
+
+        // Accept either a simple name or a fully-qualified name.
+        if ($this->isFullyQualifiedName('topic', $topicName)) {
+            $this->topicName = $topicName;
+        } else {
+            $this->topicName = !is_null($topicName)
+                ? $this->formatName('topic', $topicName, $projectId)
+                : null;
+        }
+    }
+
+    /**
+     * Execute a service request creating the subscription.
+     *
+     * The suggested way of creating a subscription is by calling through
+     * {@see Topic::subscribe()} or {@see Topic::subscription()}.
+     *
+     * Returns subscription info in the format detailed in the documentation
+     * for a [https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions#Subscription](subscription}.
+     *
+     * **NOTE: Some methods of instantiation of a Subscription do not supply a
+     * topic name. The topic name is required to create a subscription.**
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     *
+     * $subscription = $topic->subscription('my-new-subscription');
+     * $result = $subscription->create();
+     * ```
+     *
+     * @param  array $options {
+     *     Configuration Options
+     *
+     *     @type int $ackDeadlineSeconds This value is the maximum time after a
+     *           subscriber receives a message before the subscriber should
+     *           acknowledge the message. If not set, the default value of 10 is
+     *           used.
+     *     @type array $pushConfig See {@see Subscription::modifyPushConfig()} or
+     *           [PushConfig](https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions#PushConfig)
+     *           for usage.
+     * }
+     * @return array An array of subscription info
+     * @throws \InvalidArgumentException
+     */
+    public function create(array $options = [])
+    {
+        // If a subscription is created via PubSubClient::subscription(),
+        // it may or may not have a topic name. This is fine for most API
+        // interactions, but a topic name is required to create a subscription.
+        if (!$this->topicName) {
+            throw new InvalidArgumentException('A topic name is required to
+                create a subscription.');
+        }
+
+        $this->info = $this->connection->createSubscription($options + [
+            'name' => $this->name,
+            'topic' => $this->topicName
+        ]);
+
+        return $this->info;
+    }
+
+    /**
+     * Delete a subscription
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * $subscription->delete();
+     * ```
+     *
+     * @param  array $options Configuration Options.
+     * @return void
+     */
+    public function delete(array $options = [])
+    {
+        $this->connection->deleteSubscription($options + [
+            'subscription' => $this->name
+        ]);
+    }
+
+    /**
+     * Check if a subscription exists.
+     *
+     * Service errors will NOT bubble up from this method. It will always return
+     * a boolean value. If you want to check for errors, use
+     * {@see Subscription::info()}.
+     *
+     * If you need to re-check the existence of a subscription that is already
+     * downloaded, call {@see Subscription::reload()} first to refresh the
+     * cached information.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * if ($subscription->exists()) {
+     *      // do stuff
+     * }
+     * ```
+     *
+     * @param  array $options Configuration Options
+     * @return bool
+     */
+    public function exists(array $options = [])
+    {
+        try {
+            $this->info($options);
+            return true;
+        } catch (NotFoundException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Get info on a subscription
+     *
+     * If the info is already cached on the object, it will return that result.
+     * To fetch a fresh result, use {@see Subscription::reload()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * $info = $subscription->info();
+     * echo $info['name']; // `projects/my-awesome-project/subscriptions/my-new-subscription`
+     * ```
+     *
+     * @param  array $options Configuration Options
+     * @return array Subscription data
+     */
+    public function info(array $options = [])
+    {
+        if (!$this->info) {
+            $this->reload($options);
+        }
+
+        return $this->info;
+    }
+
+    /**
+     * Retrieve info on a subscription from the API.
+     *
+     * To use the previously cached result (if it exists), use
+     * {@see Subscription::info()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * $subscription->reload();
+     * $info = $subscription->info();
+     * echo $info['name']; // `projects/my-awesome-project/subscriptions/my-new-subscription`
+     * ```
+     *
+     * @param  array $options Configuration Options
+     * @return array Subscription data
+     */
+    public function reload(array $options = [])
+    {
+        return $this->info = $this->connection->getSubscription($options + [
+            'subscription' => $this->name
+        ]);
+    }
+
+    /**
+     * Retrieve new messages from the topic.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * $messages = $subscription->pull();
+     * foreach ($messages as $message) {
+     *      echo $message['data'];
+     * }
+     * ```
+     *
+     * @param  array $options {
+     *      Configuration Options
+     *
+     *      @type bool $returnImmediately If set, the system will respond
+     *            immediately, even if no messages are available. Otherwise,
+     *            wait until new messages are available.
+     *      @type int  $maxMessages Limit the amount of messages pulled.
+     * }
+     * @return \Generator
+     */
+    public function pull(array $options = [])
+    {
+        $options['pageToken'] = null;
+        $options['returnImmediately'] = isset($options['returnImmediately'])
+            ? $options['returnImmediately']
+            : false;
+
+        $options['maxMessages'] = isset($options['maxMessages'])
+            ? $options['maxMessages']
+            : self::MAX_MESSAGES;
+
+        do {
+            $response = $this->connection->pull($options + [
+                'subscription' => $this->name
+            ]);
+
+            foreach ($response['receivedMessages'] as $message) {
+                yield $message;
+            }
+
+            // If there's a page token, we'll request the next page.
+            $options['pageToken'] = isset($response['nextPageToken'])
+                ? $response['nextPageToken']
+                : null;
+        } while ($options['pageToken']);
+    }
+
+    /**
+     * Acknowledge receipt of a message.
+     *
+     * Use {@see Subscription::acknowledgeBatch()} to acknowledge multiple messages
+     * at once.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * $messages = $subscription->pull();
+     *
+     * $lastMessageAckId = null;
+     *
+     * foreach ($messages as $message) {
+     *      $lastMessageAckId = $message['ackId'];
+     * }
+     *
+     * if (!is_null($lastMessageAckId)) {
+     *      $subscription->acknowledge($lastMessageAckId);
+     * }
+     * ```
+     *
+     * @param  int   $ackId
+     * @param  array $options Configuration Options
+     * @return void
+     */
+    public function acknowledge($ackId, array $options = [])
+    {
+        return $this->acknowledgeBatch([$ackId], $options);
+    }
+
+    /**
+     * Acknowledge receipt of multiple messages at once.
+     *
+     * Use {@see Subscription::acknowledge()} to acknowledge a single message.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * $messages = $subscription->pull();
+     *
+     * $ackIds = [];
+     * foreach ($messages as $message) {
+     *      $ackIds[] = $message['ackId'];
+     * }
+     *
+     * if (!empty($lastMessageId)) {
+     *      $subscription->acknowledgeBatch($ackIds);
+     * }
+     * ```
+     *
+     * @param  array $ackIds
+     * @param  array $options Configuration Options
+     * @return void
+     */
+    public function acknowledgeBatch(array $ackIds, array $options = [])
+    {
+        return $this->connection->acknowledge($options + [
+            'subscription' => $this->name,
+            'ackIds' => $ackIds
+        ]);
+    }
+
+    /**
+     * Set the acknowledge deadline for a single ackId.
+     *
+     * Use {@see Subscription::modifyAckDeadlineBatch()} to modify the ack deadline for
+     * multiple messages at once.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * $messages = $subscription->pull();
+     *
+     * foreach ($messages as $message) {
+     *      $subscription->modifyAckDeadline($message['ackId'], 90);
+     *      sleep(80);
+     *
+     *      // Now we'll acknowledge!
+     *      $subscription->acknowledge($message['ackId']);
+     *
+     *      break;
+     * }
+     * ```
+     *
+     * @param  string $ackId An acknowledgement ID
+     * @param  int    $seconds The new ack deadline with respect to the time
+     *         this request was sent to the Pub/Sub system. Must be >= 0. For
+     *         example, if the value is 10, the new ack deadline will expire 10
+     *         seconds after the ModifyAckDeadline call was made. Specifying
+     *         zero may immediately make the message available for another pull
+     *         request.
+     * @param  array  $options Configuration Options
+     * @return void
+     */
+    public function modifyAckDeadline($ackId, $seconds, array $options = [])
+    {
+        return $this->modifyAckDeadlineBatch([$ackId], $seconds, $options);
+    }
+
+    /**
+     * Set the acknowledge deadline for multiple ackIds.
+     *
+     * Use {@see Subscription::modifyAckDeadline()} to modify the ack deadline for a
+     * single message.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $subscription = $pubsub->subscription('my-new-subscription');
+     * $messages = $subscription->pull();
+     *
+     * $ackIds = [];
+     * foreach ($messages as $message) {
+     *      $ackIds[] = $message['ackId'];
+     * }
+     *
+     * // Set the ack deadline to a minute and a half from now for every message
+     * $subscription->modifyAckDeadlineBatch($ackIds, 90);
+     *
+     * // Delay execution, or make a sandwich or something.
+     * sleep(80);
+     *
+     * // Now we'll acknowledge
+     * $subscription->acknowledge($ackIds);
+     * ```
+     *
+     * @param  string $ackIds List of acknowledgment IDs.
+     * @param  int    $seconds The new ack deadline with respect to the time
+     *         this request was sent to the Pub/Sub system. Must be >= 0. For
+     *         example, if the value is 10, the new ack deadline will expire 10
+     *         seconds after the ModifyAckDeadline call was made. Specifying
+     *         zero may immediately make the message available for another pull
+     *         request.
+     * @param  array  $options Configuration Options
+     * @return void
+     */
+    public function modifyAckDeadlineBatch(array $ackIds, $seconds, array $options = [])
+    {
+        return $this->connection->modifyAckDeadline($options + [
+            'subscription' => $this->name,
+            'ackIds' => $ackIds,
+            'ackDeadlineSeconds' => $seconds
+        ]);
+    }
+
+    /**
+     * Set the push config for the subscription
+     *
+     * @param  array $pushConfig {
+     *     Push delivery configuration
+     *
+     *     See [PushConfig](https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions#PushConfig)
+     *     for more details.
+     *
+     *     @type string $pushEndpoint A URL locating the endpoint to which
+     *           messages should be pushed. For example, a Webhook endpoint
+     *           might use "https://example.com/push".
+     *     @type array $attributes Endpoint configuration attributes.
+     * }
+     * @param  array $options Configuration Options
+     * @return void
+     */
+    public function modifyPushConfig(array $pushConfig, array $options = [])
+    {
+        return $this->connection->modifyPushConfig($options + [
+            'subscription' => $this->name,
+            'pushConfig' => $pushConfig
+        ]);
+    }
+
+    /**
+     * Present a nicer debug result to people using php 5.6 or greater.
+     * @return array
+     * @codeCoverageIgnore
+     */
+    public function __debugInfo()
+    {
+        return [
+            'name' => $this->name,
+            'topicName' => $this->topicName,
+            'projectId' => $this->projectId,
+            'info' => $this->info,
+            'connection' => get_class($this->connection)
+        ];
+    }
+}

--- a/src/PubSub/Topic.php
+++ b/src/PubSub/Topic.php
@@ -1,0 +1,542 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\PubSub;
+
+use Google\Cloud\Exception\GoogleException;
+use Google\Cloud\PubSub\Connection\ConnectionInterface;
+use InvalidArgumentException;
+
+/**
+ * A named resource to which messages are sent by publishers.
+ */
+class Topic
+{
+    use ResourceNameTrait;
+
+    /**
+     * @var string The topic name
+     */
+    private $name;
+
+    /**
+     * @var string The project ID
+     */
+    private $projectId;
+
+    /**
+     * @var ConnectionInterface A connection to the Google Cloud Platform API
+     */
+    private $connection;
+
+    /**
+     * @var array
+     */
+    private $info;
+
+    /**
+     * Create a PubSub topic.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder
+     *
+     * // The idiomatic way to get a Topic instance would be through PubSubClient:
+     *
+     * $client = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $client->pubsub();
+     * $topic = $pubsub->topic('my-topic-name');
+     *
+     * // But you can instantiate the topic directly if you want!
+     *
+     * use Google\Cloud\PubSub\Topic;
+     *
+     * $topic = new Topic($connection, 'my-topic-name', 'my-awesome-project');
+     *
+     * // You can also pass a fully-qualified topic name:
+     * $topic = new Topic(
+     *      $connection,
+     *      'projects/my-awesome-project/topics/my-topic-name',
+     *      'my-awesome-project'
+     * );
+     * ```
+     *
+     * @param  ConnectionInterface $connection (optional) A connection to the
+     *         Google Cloud Platform service
+     * @param  string $name The topic name
+     * @param  string $projectId The project Id
+     * @param  array [https://cloud.google.com/pubsub/reference/rest/v1/projects.topics#Topic](A representation of a
+     *         Topic)
+     */
+    public function __construct(
+        ConnectionInterface $connection,
+        $name,
+        $projectId,
+        array $info = null
+    ) {
+        $this->connection = $connection;
+        $this->projectId = $projectId;
+        $this->info = $info;
+
+        // Accept either a simple name or a fully-qualified name.
+        if ($this->isFullyQualifiedName('topic', $name)) {
+            $this->name = $name;
+        } else {
+            $this->name = $this->formatName('topic', $name, $projectId);
+        }
+    }
+
+    /**
+     * Create a topic.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     * $topic = $pubsub->topic('my-topic-name');
+     * if ($topic->create()) {
+     *      echo 'Topic Created!';
+     * }
+     * ```
+     *
+     * @param  array $options Configuration Options
+     * @return array Topic information
+     */
+    public function create(array $options = [])
+    {
+        $this->info = $this->connection->createTopic($options + [
+            'topic' => $this->name
+        ]);
+
+        return $this->info;
+    }
+
+    /**
+     * Delete a topic.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     * $topic = $pubsub->topic('my-topic-name');
+     *
+     * $topic->delete();
+     * ```
+     *
+     * @param  array $options Configuration Options
+     * @return void
+     */
+    public function delete(array $options = [])
+    {
+        $this->connection->deleteTopic($options + [
+            'topic' => $this->name
+        ]);
+    }
+
+    /**
+     * Check if a topic exists.
+     *
+     * Service errors will NOT bubble up from this method. It will always return
+     * a boolean value. If you want to check for errors, use
+     * {@see Topic::info()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     * if ($topic->exists()) {
+     *      // do stuff
+     * }
+     * ```
+     *
+     * @param  array $options Configuration Options
+     * @return bool
+     */
+    public function exists(array $options = [])
+    {
+        try {
+            $this->info($options);
+
+            return true;
+        } catch (GoogleException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Get topic information.
+     *
+     * Currently this resource returns only the topic name, if the topic exists.
+     * It is mostly useful therefore for checking if a topic exists.
+     *
+     * Since this method will throw an exception if the topic is not found, you
+     * may find that Topic::exists() is a better fit for a true/false check.
+     *
+     * This method will use the previously cached result, if available. To force
+     * a refresh from the API, use {@see Topic::reload()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     * $info = $topic->info();
+     * echo $info['name']; // projects/my-awesome-project/topics/my-topic-name
+     * ```
+     *
+     * @param  array $options Configuration Options
+     * @return array [https://cloud.google.com/pubsub/reference/rest/v1/projects.topics#Topic](A representation of a
+     *         Topic)
+     */
+    public function info(array $options = [])
+    {
+        if (!$this->info) {
+            $this->reload($options);
+        }
+
+        return $this->info;
+    }
+
+    /**
+     * Get topic information from the API.
+     *
+     * Currently this resource returns only the topic name, if the topic exists.
+     * It is mostly useful therefore for checking if a topic exists.
+     *
+     * Since this method will throw an exception if the topic is not found, you
+     * may find that Topic::exists() is a better fit for a true/false check.
+     *
+     * This method will retrieve a new result from the API. To use a previously
+     * cached result, if one exists, use {@see Topic::info()}.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     * $topic->reload();
+     * $info = $topic->info();
+     * echo $info['name']; // projects/my-awesome-project/topics/my-topic-name
+     * ```
+     *
+     * @param  array $options Configuration Options
+     * @return array [https://cloud.google.com/pubsub/reference/rest/v1/projects.topics#Topic](A representation of a
+     *         Topic)
+     */
+    public function reload(array $options = [])
+    {
+        return $this->info = $this->connection->getTopic($options + [
+            'topic' => $this->name
+        ]);
+    }
+
+    /**
+     * Publish a new message to the topic.
+     *
+     * $message must provide at least one of `data` and `attributes` members.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     * $topic->publish([
+     *      'data' => New User Registered',
+     *      'attributes' => [
+     *          'id' => 1,
+     *          'userName' => 'John',
+     *          'location' => 'Detroit'
+     *      ]
+     * ]);
+     * ```
+     * @param  string $message {
+     *     [https://cloud.google.com/pubsub/reference/rest/v1/PubsubMessage](Message Format)
+     *
+     *     @type string $data       The message payload
+     *     @type array  $attributes An array containing a list of key/value
+     *                              pairs
+     * }
+     * @param  array  $options {
+     *     Configuration Options
+     *
+     *     @type bool $encode True by default. If set to false, the message data
+     *           will not be base64-encoded. Only turn this off if you have
+     *           already encoded your message data.
+     * }
+     * @return array  A list of message IDs
+     */
+    public function publish(array $message, array $options = [])
+    {
+        return $this->publishBatch([$message], $options);
+    }
+
+    /**
+     * Publish multiple messages at once.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     * $topic->publishBatch([
+     *      [
+     *          'data' => New User Registered',
+     *          'attributes' => [
+     *              'id' => 1,
+     *              'userName' => 'John',
+     *              'location' => 'Detroit'
+     *          ]
+     *      ], [
+     *          'data' => New User Registered',
+     *          'attributes' => [
+     *              'id' => 2,
+     *              'userName' => 'Steve',
+     *              'location' => 'Mountain View'
+     *          ]
+     *      ]
+     * ]);
+     * ```
+     *
+     * @param  array $messages {
+     *     A list of messages. Each message must be in the correct format.
+     *
+     *     If provided, $data will be base64 encoded before being published,
+     *     unless `$options['encode']` is set to false. (See below for more
+     *     details.)
+     *
+     *     @type array [https://cloud.google.com/pubsub/reference/rest/v1/PubsubMessage Message](Format)
+     * }
+     * @param  array $options {
+     *     Configuration Options
+     *
+     *     @type bool $encode True by default. If set to false, the message data
+     *           will not be base64-encoded. Only turn this off if you have
+     *           already encoded your message data.
+     * }
+     * @return array A list of message IDs.
+     */
+    public function publishBatch(array $messages, array $options = [])
+    {
+        $encode = (isset($options['encode'])) ? $options['encode'] : true;
+
+        foreach ($messages as &$message) {
+            $message = $this->formatMessage($message, $encode);
+        }
+
+        return $this->connection->publishMessage($options + [
+            'topic' => $this->name,
+            'messages' => $messages
+        ]);
+    }
+
+    /**
+     * Create a subscription to the topic.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     *
+     * $topic->subscribe('my-new-subscription');
+     * ```
+     *
+     * @param  string $name
+     * @param  array  $options Please see {@see Subscription::create()} for configuration details.
+     * @return Subscription
+     */
+    public function subscribe($name, array $options = [])
+    {
+        $subscription = $this->subscription($name);
+
+        $subscription->create($options);
+
+        return $subscription;
+    }
+
+    /**
+     * This method will not run any API requests. You will receive a
+     * Subscription object that you can use to interact with the API.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     *
+     * $topic->subscribe('my-new-subscription');
+     * ```
+     *
+     * @param  string $name
+     * @param  array $info  [https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions#Subscription](A
+     *         representation of a Subscription)
+     * @return Subscription
+     */
+    public function subscription($name, array $info = null)
+    {
+        return new Subscription(
+            $this->connection,
+            $name,
+            $this->name,
+            $this->projectId,
+            $info
+        );
+    }
+
+    /**
+     * Retrieve a list of active subscriptions to the current topic.
+     *
+     * Example:
+     * ```php
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * $cloud = new ServiceBuilder([
+     *      'projectId' => 'my-awesome-project'
+     * ]);
+     *
+     * $pubsub = $cloud->pubsub();
+     *
+     * $topic = $pubsub->topic('my-topic-name');
+     *
+     * $subscriptions = $topic->subscriptions();
+     * foreach ($subscriptions as $subscription) {
+     *     var_dump($subscription->info());
+     * }
+     * ```
+     *
+     * @param  array     $options {
+     *     Configuration Options
+     *
+     *     @type int $pageSize Maximum number of subscriptions to return.
+     * }
+     * @return Generator Populated with Subscription objects
+     */
+    public function subscriptions(array $options = [])
+    {
+        $options['pageToken'] = null;
+
+        do {
+            $response = $this->connection->listSubscriptionsByTopic($options + [
+                'topic' => $this->name
+            ]);
+
+            foreach ($response['subscriptions'] as $subscription) {
+                yield $this->subscription($subscription['name'], $subscription);
+            }
+
+            // If there's a page token, we'll request the next page.
+            $options['pageToken'] = isset($response['nextPageToken'])
+                ? $response['nextPageToken']
+                : null;
+        } while ($options['pageToken']);
+    }
+
+    /**
+     * Present a nicer debug result to people using php 5.6 or greater.
+     * @return array
+     * @codeCoverageIgnore
+     */
+    public function __debugInfo()
+    {
+        return [
+            'name' => $this->name,
+            'projectId' => $this->projectId,
+            'info' => $this->info,
+            'connection' => get_class($this->connection)
+        ];
+    }
+
+    /**
+     * Ensure that the message is in a correct format,
+     * base64_encode the data, and error if the input is too wrong to proceed.
+     * @param  array $message
+     * @param  bool  $encode
+     * @return array The message data
+     * @throws \InvalidArgumentException
+     */
+    private function formatMessage(array $message, $encode = true)
+    {
+        if (isset($message['data']) && $encode) {
+            $message['data'] = base64_encode($message['data']);
+        }
+
+        if (!array_key_exists('data', $message) &&
+            !array_key_exists('attributes', $message)) {
+            throw new InvalidArgumentException('At least one of $data or
+                $attributes must be specified on each message, but neither
+                was given.');
+        }
+
+        return $message;
+    }
+}

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -70,7 +70,9 @@ class RequestBuilder
     {
         $root = $this->resourceRoot;
 
-        array_push($root, 'resources', $resource, 'methods', $method);
+        array_push($root, 'resources');
+        $root = array_merge($root, explode('.', $resource));
+        array_push($root, 'methods', $method);
 
         $action = $this->service;
         foreach ($root as $rootItem) {

--- a/src/ServiceBuilder.php
+++ b/src/ServiceBuilder.php
@@ -19,6 +19,7 @@ namespace Google\Cloud;
 
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\Storage\StorageClient;
 
 /**
@@ -132,6 +133,32 @@ class ServiceBuilder
     public function bigQuery(array $config = [])
     {
         return new BigQueryClient($config ? $this->resolveConfig($config) : $this->config);
+    }
+
+    /**
+     * Google Cloud Pub/Sub client. Allows you to send and receive
+     * messages between independent applications. Find more information at
+     * [Google Cloud Pub/Sub docs](https://cloud.google.com/pubsub/docs/).
+     *
+     * Example:
+     * ```
+     * use Google\Cloud\ServiceBuilder;
+     *
+     * // Create a storage client using application default credentials.
+     * $builder = new ServiceBuilder([
+     *     'projectId' => 'myAwesomeProject'
+     * ]);
+     *
+     * $pubsub = $builder->pubsub();
+     * ```
+     *
+     * @param array $config Configuration options. See
+     *        {@see Google\Cloud\ServiceBuilder::__construct()} for the available options.
+     * @return PubSubClient
+     */
+    public function pubsub(array $config = [])
+    {
+        return new PubSubClient($config ? $this->resolveConfig($config) : $this->config);
     }
 
     /**

--- a/tests/PubSub/Connection/RestTest.php
+++ b/tests/PubSub/Connection/RestTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\PubSub\Connection;
+
+use Google\Cloud\PubSub\Connection\Rest;
+use Google\Cloud\RequestBuilder;
+use Google\Cloud\RequestWrapper;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Rize\UriTemplate;
+
+class RestTest extends \PHPUnit_Framework_TestCase
+{
+    private $requestWrapper;
+    private $successBody;
+
+    public function setUp()
+    {
+        $this->requestWrapper = $this->prophesize(RequestWrapper::class);
+        $this->successBody = '{"canI":"kickIt"}';
+    }
+
+    /**
+     * @dataProvider methodProvider
+     * @todo revisit this approach
+     */
+    public function testCallBasicMethods($method)
+    {
+        $options = [];
+        $request = new Request('GET', '/somewhere');
+        $response = new Response(200, [], $this->successBody);
+
+        $requestBuilder = $this->prophesize(RequestBuilder::class);
+        $requestBuilder->build(
+            Argument::type('string'),
+            Argument::type('string'),
+            Argument::type('array')
+        )->willReturn($request);
+
+        $this->requestWrapper->send(
+            Argument::type(RequestInterface::class),
+            Argument::type('array')
+        )->willReturn($response);
+
+        $rest = new Rest();
+        $rest->setRequestBuilder($requestBuilder->reveal());
+        $rest->setRequestWrapper($this->requestWrapper->reveal());
+
+        $this->assertEquals(json_decode($this->successBody, true), $rest->$method($options));
+    }
+
+    public function methodProvider()
+    {
+        return [
+            ['createTopic'],
+            ['getTopic'],
+            ['deleteTopic'],
+            ['listTopics'],
+            ['publishMessage'],
+            ['listSubscriptionsByTopic'],
+            ['createSubscription'],
+            ['getSubscription'],
+            ['listSubscriptions'],
+            ['deleteSubscription'],
+            ['modifyPushConfig'],
+            ['pull'],
+            ['modifyAckDeadline'],
+            ['acknowledge'],
+        ];
+    }
+}

--- a/tests/PubSub/PubSubClientTest.php
+++ b/tests/PubSub/PubSubClientTest.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\PubSub;
+
+use Generator;
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\Subscription;
+use Google\Cloud\PubSub\Topic;
+use Prophecy\Argument;
+
+class PubSubClientTest extends \PHPUnit_Framework_TestCase
+{
+    private $connection;
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize('Google\Cloud\PubSub\Connection\ConnectionInterface');
+
+        $this->client = new PubSubClientStub(['projectId' => 'project']);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testWithMissingProjectId()
+    {
+        new PubSubClient([]);
+    }
+
+    public function testCreateTopic()
+    {
+        $topicName = 'test-topic';
+
+        $this->connection->createTopic(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'name' => 'projects/project/topics/'. $topicName
+            ]);
+
+        // Set this to zero to make sure we're getting the cached result
+        $this->connection->getTopic(Argument::any())->shouldNotBeCalled();
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $topic = $this->client->createTopic($topicName, [
+            'foo' => 'bar'
+        ]);
+
+        $this->assertInstanceOf(Topic::class, $topic);
+
+        $info = $topic->info();
+        $this->assertEquals($info['name'], 'projects/project/topics/'. $topicName);
+    }
+
+    public function testTopic()
+    {
+        $topicName = 'test-topic';
+
+        $this->connection->getTopic(Argument::any())
+            ->willReturn([
+                'name' => 'projects/project/topics/'. $topicName
+            ])->shouldBeCalledTimes(1);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $topic = $this->client->topic($topicName);
+
+        $this->assertInstanceOf(Topic::class, $topic);
+
+        $info = $topic->info();
+        $this->assertEquals($info['name'], 'projects/project/topics/'. $topicName);
+    }
+
+    public function testTopics()
+    {
+        $topicResult = [
+            [
+                'name' => 'projects/project/topics/topic-a'
+            ], [
+                'name' => 'projects/project/topics/topic-b'
+            ], [
+                'name' => 'projects/project/topics/topic-c'
+            ]
+        ];
+
+        $this->connection->listTopics(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'topics' => $topicResult
+            ])->shouldBeCalledTimes(1);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $topics = $this->client->topics([
+            'foo' => 'bar'
+        ]);
+
+        $this->assertInstanceOf(Generator::class, $topics);
+
+        $arr = iterator_to_array($topics);
+        $this->assertInstanceOf(Topic::class, $arr[0]);
+        $this->assertEquals($arr[0]->info()['name'], $topicResult[0]['name']);
+        $this->assertEquals($arr[1]->info()['name'], $topicResult[1]['name']);
+        $this->assertEquals($arr[2]->info()['name'], $topicResult[2]['name']);
+    }
+
+    public function testTopicsPaged()
+    {
+        $topicResult = [
+            [
+                'name' => 'projects/project/topics/topic-a'
+            ], [
+                'name' => 'projects/project/topics/topic-b'
+            ], [
+                'name' => 'projects/project/topics/topic-c'
+            ]
+        ];
+
+        $this->connection->listTopics(Argument::that(function ($options) {
+            if ($options['foo'] !== 'bar') return false;
+            if ($options['pageToken'] !== 'foo' && !is_null($options['pageToken'])) return false;
+
+            return true;
+        }))->willReturn([
+            'topics' => $topicResult,
+            'nextPageToken' => 'foo'
+        ])->shouldBeCalledTimes(2);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $topics = $this->client->topics([
+            'foo' => 'bar'
+        ]);
+
+        // enumerate the iterator and kill after it loops twice.
+        $arr = [];
+        $i = 0;
+        foreach ($topics as $topic) {
+            $i++;
+            $arr[] = $topic;
+            if ($i == 6) break;
+        }
+
+        $this->assertEquals(6, count($arr));
+    }
+
+    public function testSubscribe()
+    {
+        $this->connection->createSubscription(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'test' => 'value'
+            ])->shouldBeCalledTimes(1);
+
+        $this->connection->getSubscription()->shouldNotBeCalled();
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $subscription = $this->client->subscribe('subscription', 'topic', [
+            'foo' => 'bar'
+        ]);
+
+        $this->assertInstanceOf(Subscription::class, $subscription);
+        $this->assertEquals('value', $subscription->info()['test']);
+    }
+
+    public function testSubscription()
+    {
+        $subscription = $this->client->subscription('subscription-name', 'topic-name', [
+            'foo' => 'bar'
+        ]);
+
+        $info = $subscription->info();
+
+        $this->assertInstanceOf(Subscription::class, $subscription);
+
+        $this->assertEquals('bar', $info['foo']);
+    }
+
+    public function testSubscriptions()
+    {
+        $subscriptionResult = [
+            [
+                'name' => 'projects/project/subscriptions/subscription-a',
+                'topic' => 'projects/project/topics/topic-a'
+            ], [
+                'name' => 'projects/project/subscriptions/subscription-b',
+                'topic' => 'projects/project/topics/topic-a'
+            ], [
+                'name' => 'projects/project/subscriptions/subscription-c',
+                'topic' => 'projects/project/topics/topic-a'
+            ]
+        ];
+
+        $this->connection->listSubscriptions(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'subscriptions' => $subscriptionResult
+            ])->shouldBeCalledTimes(1);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $subscriptions = $this->client->subscriptions([
+            'foo' => 'bar'
+        ]);
+
+        $this->assertInstanceOf(Generator::class, $subscriptions);
+
+        $arr = iterator_to_array($subscriptions);
+        $this->assertInstanceOf(Subscription::class, $arr[0]);
+        $this->assertEquals($arr[0]->info()['name'], $subscriptionResult[0]['name']);
+        $this->assertEquals($arr[1]->info()['name'], $subscriptionResult[1]['name']);
+        $this->assertEquals($arr[2]->info()['name'], $subscriptionResult[2]['name']);
+    }
+
+    public function testSubscriptionsPaged()
+    {
+        $subscriptionResult = [
+            [
+                'name' => 'projects/project/subscriptions/subscription-a',
+                'topic' => 'projects/project/topics/topic-a'
+            ], [
+                'name' => 'projects/project/subscriptions/subscription-b',
+                'topic' => 'projects/project/topics/topic-a'
+            ], [
+                'name' => 'projects/project/subscriptions/subscription-c',
+                'topic' => 'projects/project/topics/topic-a'
+            ]
+        ];
+
+        $this->connection->listSubscriptions(Argument::that(function ($options) {
+            if ($options['foo'] !== 'bar') return false;
+            if ($options['pageToken'] !== 'foo' && !is_null($options['pageToken'])) return false;
+
+            return true;
+        }))->willReturn([
+            'subscriptions' => $subscriptionResult,
+            'nextPageToken' => 'foo'
+        ])->shouldBeCalledTimes(2);
+
+        $this->client->setConnection($this->connection->reveal());
+
+        $subscriptions = $this->client->subscriptions([
+            'foo' => 'bar'
+        ]);
+
+        // enumerate the iterator and kill after it loops twice.
+        $arr = [];
+        $i = 0;
+        foreach ($subscriptions as $subscription) {
+            $i++;
+            $arr[] = $subscription;
+            if ($i == 6) break;
+        }
+
+        $this->assertEquals(6, count($arr));
+    }
+}
+
+class PubSubClientStub extends PubSubClient
+{
+    public function setConnection($connection)
+    {
+        $this->connection = $connection;
+    }
+}

--- a/tests/PubSub/ResourceNameTraitTest.php
+++ b/tests/PubSub/ResourceNameTraitTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\PubSub;
+
+use Google\Cloud\PubSub\ResourceNameTrait;
+
+class ResourceNameTraitTest extends \PHPUnit_Framework_TestCase
+{
+    private $trait;
+
+    public function setUp()
+    {
+        $this->trait = $this->getObjectForTrait(ResourceNameTrait::class);
+    }
+
+    public function testPluckProjectId()
+    {
+        $res = $this->trait->pluckName(
+            'project',
+            'projects/foo'
+        );
+
+        $this->assertEquals('foo', $res);
+    }
+
+    public function testPluckTopicName()
+    {
+        $res = $this->trait->pluckName(
+            'topic',
+            'projects/foo/topics/bar'
+        );
+
+        $this->assertEquals('bar', $res);
+    }
+
+    public function testPluckSubscriptionName()
+    {
+        $res = $this->trait->pluckName(
+            'subscription',
+            'projects/foo/subscriptions/bar'
+        );
+
+        $this->assertEquals('bar', $res);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testPluckNameInvalidFormat()
+    {
+        $this->trait->pluckName('lame', 'bar');
+    }
+
+    public function testFormatProjectId()
+    {
+        $res = $this->trait->formatName('project', 'foo');
+
+        $this->assertEquals('projects/foo', $res);
+    }
+
+    public function testFormatTopicName()
+    {
+        $res = $this->trait->formatName('topic', 'foo', 'my-project');
+
+        $this->assertEquals('projects/my-project/topics/foo', $res);
+    }
+
+    public function testFormatSubscriptionName()
+    {
+        $res = $this->trait->formatName('subscription', 'foo', 'my-project');
+
+        $this->assertEquals('projects/my-project/subscriptions/foo', $res);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testFormatNameInvalidType()
+    {
+        $this->trait->formatName('lame', ['foo']);
+    }
+
+    public function testIsFullyQualifiedProjectId()
+    {
+        $this->assertTrue($this->trait->isFullyQualifiedName(
+            'project',
+            'projects/foo'
+        ));
+
+        $this->assertFalse($this->trait->isFullyQualifiedName(
+            'project',
+            'foo'
+        ));
+    }
+
+    public function testIsFullyQualifiedTopicName()
+    {
+        $this->assertTrue($this->trait->isFullyQualifiedName(
+            'topic',
+            'projects/foo/topics/bar'
+        ));
+
+        $this->assertFalse($this->trait->isFullyQualifiedName(
+            'topic',
+            'foo'
+        ));
+    }
+
+    public function testIsFullyQualifiedSubscriptionName()
+    {
+        $this->assertTrue($this->trait->isFullyQualifiedName(
+            'subscription',
+            'projects/foo/subscriptions/bar'
+        ));
+
+        $this->assertFalse($this->trait->isFullyQualifiedName(
+            'subscription',
+            'foo'
+        ));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testIsFullyQualifiedNameInvalidType()
+    {
+        $this->trait->isFullyQualifiedName('lame', 'foo');
+    }
+}

--- a/tests/PubSub/SubscriptionTest.php
+++ b/tests/PubSub/SubscriptionTest.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\PubSub;
+
+use Generator;
+use Google\Cloud\Exception\NotFoundException;
+use Google\Cloud\PubSub\Subscription;
+use Prophecy\Argument;
+
+class SubscriptionTest extends \PHPUnit_Framework_TestCase
+{
+    private $connection;
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize('Google\Cloud\PubSub\Connection\ConnectionInterface');
+    }
+
+    public function testCreate()
+    {
+        $this->connection->createSubscription(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'name' => 'projects/project-id/subscriptions/subscription-name',
+                'topic' => 'projects/project-id/topics/topic-name'
+            ])->shouldBeCalledTimes(1);
+
+        $this->connection->getSubscription()->shouldNotBeCalled();
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $sub = $subscription->create([ 'foo' => 'bar' ]);
+
+        $this->assertEquals($sub['name'], 'projects/project-id/subscriptions/subscription-name');
+        $this->assertEquals($sub['topic'], 'projects/project-id/topics/topic-name');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCreateWithoutTopicName()
+    {
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            null,
+            'project-id'
+        );
+
+        $sub = $subscription->create();
+    }
+
+    public function testDelete()
+    {
+        $this->connection->deleteSubscription(Argument::withEntry('foo', 'bar'))
+            ->willReturn(null)
+            ->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $res = $subscription->delete([ 'foo' => 'bar' ]);
+
+        $this->assertNull($res);
+    }
+
+    public function testExists()
+    {
+        $this->connection->getSubscription(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'subscription' => 'projects/project-id/subscriptions/subscription-name',
+                'topic' => 'projects/project-id/topics/topic-name'
+            ])->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $this->assertTrue($subscription->exists([ 'foo' => 'bar' ]));
+    }
+
+    public function testExistsNotFound()
+    {
+        $this->connection->getSubscription(Argument::any())
+            ->willThrow(new NotFoundException('bad'))
+            ->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $this->assertFalse($subscription->exists());
+    }
+
+    public function testInfo()
+    {
+        $sub = [
+            'subscription' => 'projects/project-id/subscriptions/subscription-name',
+            'topic' => 'projects/project-id/topics/topic-name'
+        ];
+
+        $this->connection->getSubscription(Argument::withEntry('foo', 'bar'))
+            ->willReturn($sub)
+            ->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $res = $subscription->info([ 'foo' => 'bar' ]);
+        $this->assertEquals($res, $sub);
+    }
+
+    public function testInfoNoRequest()
+    {
+        $sub = [
+            'subscription' => 'projects/project-id/subscriptions/subscription-name',
+            'topic' => 'projects/project-id/topics/topic-name'
+        ];
+
+        $this->connection->getSubscription()->shouldNotBeCalled();
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id',
+            $sub
+        );
+
+        $res = $subscription->info();
+        $this->assertEquals($res, $sub);
+    }
+
+    public function testReload()
+    {
+        $sub = [
+            'subscription' => 'projects/project-id/subscriptions/subscription-name',
+            'topic' => 'projects/project-id/topics/topic-name'
+        ];
+
+        $this->connection->getSubscription(Argument::withEntry('foo', 'bar'))
+            ->willReturn($sub)
+            ->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $res = $subscription->reload([ 'foo' => 'bar' ]);
+        $this->assertEquals($res, $sub);
+    }
+
+    public function testPull()
+    {
+        $messages = [
+            'receivedMessages' => [
+                [
+                    'foo' => 'bar'
+                ], [
+                    'foo' => 'bat'
+                ]
+            ]
+        ];
+
+        $this->connection->pull(Argument::withEntry('foo', 'bar'))
+            ->willReturn($messages)
+            ->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $result = $subscription->pull([
+            'foo' => 'bar'
+        ]);
+
+        $this->assertInstanceOf(Generator::class, $result);
+
+        $arr = iterator_to_array($result);
+        $this->assertEquals($arr[0]['foo'], 'bar');
+        $this->assertEquals($arr[1]['foo'], 'bat');
+    }
+
+    public function testPullWithCustomArgs()
+    {
+        $messages = [
+            'receivedMessages' => [
+                [
+                    'foo' => 'bar'
+                ], [
+                    'foo' => 'bat'
+                ]
+            ]
+        ];
+
+        $this->connection->pull(Argument::that(function ($args) {
+                if ($args['foo'] !== 'bar') return false;
+                if ($args['returnImmediately'] !== true) return false;
+                if ($args['maxMessages'] !== 2) return false;
+
+                return true;
+            }))->willReturn($messages)
+            ->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $result = $subscription->pull([
+            'foo' => 'bar',
+            'returnImmediately' => true,
+            'maxMessages' => 2
+        ]);
+
+        $this->assertInstanceOf(Generator::class, $result);
+
+        $arr = iterator_to_array($result);
+        $this->assertEquals($arr[0]['foo'], 'bar');
+        $this->assertEquals($arr[1]['foo'], 'bat');
+    }
+
+    public function testPullPaged()
+    {
+        $messages = [
+            'receivedMessages' => [
+                [
+                    'foo' => 'bar'
+                ], [
+                    'foo' => 'bat'
+                ]
+            ],
+            'nextPageToken' => 'foo'
+        ];
+
+        $this->connection->pull(Argument::that(function ($args) {
+                if ($args['foo'] !== 'bar') return false;
+                if ($args['returnImmediately'] !== true) return false;
+                if ($args['maxMessages'] !== 2) return false;
+                if (!in_array($args['pageToken'], [null, 'foo'])) return false;
+
+                return true;
+            }))->willReturn($messages)
+            ->shouldBeCalledTimes(3);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $result = $subscription->pull([
+            'foo' => 'bar',
+            'returnImmediately' => true,
+            'maxMessages' => 2
+        ]);
+
+        $this->assertInstanceOf(Generator::class, $result);
+
+        // enumerate the iterator and kill after it loops twice.
+        $arr = [];
+        $i = 0;
+        foreach ($result as $message) {
+            $i++;
+            $arr[] = $message;
+            if ($i == 6) break;
+        }
+
+        $this->assertEquals(6, count($arr));
+    }
+
+    public function testAcknowledge()
+    {
+        $ackId = 'foobar';
+
+        $this->connection->acknowledge(Argument::that(function ($args) use ($ackId) {
+            if ($args['foo'] !== 'bar') return false;
+            if ($args['ackIds'] !== [$ackId]) return false;
+
+            return true;
+        }))->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $subscription->acknowledge($ackId, ['foo' => 'bar']);
+    }
+
+    public function testAcknowledgeBatch()
+    {
+        $ackIds = [
+            'foobar',
+            'otherAckId'
+        ];
+
+        $this->connection->acknowledge(Argument::that(function ($args) use ($ackIds) {
+            if ($args['foo'] !== 'bar') return false;
+            if ($args['ackIds'] !== $ackIds) return false;
+
+            return true;
+        }))->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $subscription->acknowledgeBatch($ackIds, ['foo' => 'bar']);
+    }
+
+    public function testModifyAckDeadline()
+    {
+        $ackId = 'foobar';
+
+        $this->connection->modifyAckDeadline(Argument::that(function ($args) use ($ackId) {
+            if ($args['foo'] !== 'bar') return false;
+            if ($args['ackIds'] !== [$ackId]) return false;
+
+            return true;
+        }))->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $subscription->modifyAckDeadline($ackId, 100, ['foo' => 'bar']);
+    }
+
+    public function testModifyAckDeadlineBatch()
+    {
+        $ackIds = [
+            'foobar',
+            'otherAckId'
+        ];
+
+        $seconds = 100;
+
+        $this->connection->modifyAckDeadline(Argument::that(function ($args) use ($ackIds, $seconds) {
+            if ($args['foo'] !== 'bar') return false;
+            if ($args['ackIds'] !== $ackIds) return false;
+            if ($args['ackDeadlineSeconds'] !== $seconds) return false;
+
+            return true;
+        }))->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $subscription->modifyAckDeadlineBatch($ackIds, $seconds, ['foo' => 'bar']);
+    }
+
+    public function testModifyPushConfig()
+    {
+        $config = [
+            'hello' => 'world'
+        ];
+
+        $this->connection->modifyPushConfig(Argument::that(function ($args) use ($config) {
+            if ($args['foo'] !== 'bar') return false;
+            if ($args['pushConfig'] !== $config) return false;
+
+            return true;
+        }))->shouldBeCalledTimes(1);
+
+        $subscription = new Subscription(
+            $this->connection->reveal(),
+            'subscription-name',
+            'topic-name',
+            'project-id'
+        );
+
+        $subscription->modifyPushConfig($config, ['foo' => 'bar']);
+    }
+}

--- a/tests/PubSub/TopicTest.php
+++ b/tests/PubSub/TopicTest.php
@@ -1,0 +1,384 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\PubSub;
+
+use Generator;
+use Google\Cloud\Exception\NotFoundException;
+use Google\Cloud\PubSub\Subscription;
+use Google\Cloud\PubSub\Topic;
+use Prophecy\Argument;
+
+class TopicTest extends \PHPUnit_Framework_TestCase
+{
+    private $connection;
+
+    public function setUp()
+    {
+        $this->connection = $this->prophesize('Google\Cloud\PubSub\Connection\ConnectionInterface');
+    }
+
+    public function testCreate()
+    {
+        $this->connection->createTopic(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'name' => 'projects/project-name/topics/topic-name'
+            ]);
+
+        $this->connection->getTopic()->shouldNotBeCalled();
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $res = $topic->create(['foo' => 'bar']);
+
+        // Make sure the topic data gets cached!
+        $topic->info();
+
+        $this->assertEquals('projects/project-name/topics/topic-name', $res['name']);
+    }
+
+    public function testDelete()
+    {
+        $this->connection->deleteTopic(Argument::withEntry('foo', 'bar'));
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $res = $topic->delete(['foo' => 'bar']);
+    }
+
+    public function testExists()
+    {
+        $this->connection->getTopic(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'name' => 'projects/project-name/topics/topic-name'
+            ]);
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $this->assertTrue($topic->exists(['foo' => 'bar']));
+    }
+
+    public function testExistsReturnsFalse()
+    {
+        $this->connection->getTopic(Argument::withEntry('foo', 'bar'))
+            ->willThrow(new NotFoundException('uh oh'));
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $this->assertFalse($topic->exists(['foo' => 'bar']));
+    }
+
+    public function testInfo()
+    {
+        $this->connection->getTopic(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'name' => 'projects/project-name/topics/topic-name'
+            ])->shouldBeCalledTimes(1);
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $res = $topic->info(['foo' => 'bar']);
+        $res2 = $topic->info();
+
+        $this->assertEquals($res, $res2);
+        $this->assertEquals($res['name'], 'projects/project-name/topics/topic-name');
+    }
+
+    public function testReload()
+    {
+        $this->connection->getTopic(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'name' => 'projects/project-name/topics/topic-name'
+            ]);
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $res = $topic->reload(['foo' => 'bar']);
+
+        $this->assertEquals($res['name'], 'projects/project-name/topics/topic-name');
+    }
+
+    public function testPublish()
+    {
+        $message = [
+            'data' => 'hello world',
+            'attributes' => [
+                'key' => 'value'
+            ]
+        ];
+
+        $ids = [
+            'message1id'
+        ];
+
+        $this->connection->publishMessage(Argument::that(function ($options) use ($message) {
+            if ($options['foo'] !== 'bar') return false;
+
+            $message['data'] = base64_encode($message['data']);
+            if ($options['messages'] !== [$message]) return false;
+
+            return true;
+        }))->willReturn($ids);
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $res = $topic->publish($message, ['foo' => 'bar']);
+
+        $this->assertEquals($res, $ids);
+    }
+
+    public function testPublishBatch()
+    {
+        $messages = [
+            [
+                'data' => 'hello world',
+                'attributes' => [
+                    'key' => 'value'
+                ]
+            ], [
+                'data' => 'hello again, world',
+                'attributes' => [
+                    'key' => 'other value i guess'
+                ]
+            ]
+        ];
+
+        $ids = [
+            'message1id',
+            'message2id'
+        ];
+
+        $this->connection->publishMessage(Argument::that(function ($options) use ($messages) {
+            if ($options['foo'] !== 'bar') return false;
+
+            $messages[0]['data'] = base64_encode($messages[0]['data']);
+            $messages[1]['data'] = base64_encode($messages[1]['data']);
+            if ($options['messages'] !== $messages) return false;
+
+            return true;
+        }))->willReturn($ids);
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $res = $topic->publishBatch($messages, ['foo' => 'bar']);
+
+        $this->assertEquals($res, $ids);
+    }
+
+    public function testPublishBatchUnencoded()
+    {
+        $message = [
+            'data' => 'hello world',
+            'attributes' => [
+                'key' => 'value'
+            ]
+        ];
+
+        $this->connection->publishMessage(Argument::that(function ($options) use ($message) {
+            if ($options['foo'] !== 'bar') return false;
+
+            if ($options['messages'] !== [$message]) return false;
+
+            // If the message was encoded, this will fail the test.
+            if ($options['messages'][0]['data'] !== $message['data']) return false;
+
+            return true;
+        }));
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $res = $topic->publishBatch([$message], ['foo' => 'bar', 'encode' => false]);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testPublishMalformedMessage()
+    {
+        $message = [
+            'key' => 'val'
+        ];
+
+        $this->connection->publishMessage(Argument::any());
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $topic->publishBatch([$message]);
+    }
+
+    public function testSubscribe()
+    {
+        $subscriptionData = [
+            'name' => 'projects/project-name/subscriptions/subscription-name',
+            'topic' => 'projects/project-name/topics/topic-name'
+        ];
+
+        $this->connection->createSubscription(Argument::withEntry('foo', 'bar'))
+            ->willReturn($subscriptionData)
+            ->shouldBeCalledTimes(1);
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $subscription = $topic->subscribe('subscription-name', ['foo' => 'bar']);
+
+        $this->assertInstanceOf(Subscription::class, $subscription);
+    }
+
+    public function testSubscription()
+    {
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $subscription = $topic->subscription('subscription-name', ['name' => 'subscription-name']);
+
+        $this->assertInstanceOf(Subscription::class, $subscription);
+        $this->assertEquals('subscription-name', $subscription->info()['name']);
+    }
+
+    public function testSubscriptions()
+    {
+        $subscriptionResult = [
+            [
+                'name' => 'projects/project-name/subscriptions/subscription-a',
+                'topic' => 'projects/project-name/topics/topic-name'
+            ], [
+                'name' => 'projects/project-name/subscriptions/subscription-b',
+                'topic' => 'projects/project-name/topics/topic-name'
+            ], [
+                'name' => 'projects/project-name/subscriptions/subscription-c',
+                'topic' => 'projects/project-name/topics/topic-name'
+            ]
+        ];
+
+        $this->connection->listSubscriptionsByTopic(Argument::withEntry('foo', 'bar'))
+            ->willReturn([
+                'subscriptions' => $subscriptionResult
+            ])->shouldBeCalledTimes(1);
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $subscriptions = $topic->subscriptions([
+            'foo' => 'bar'
+        ]);
+
+        $this->assertInstanceOf(Generator::class, $subscriptions);
+
+        $arr = iterator_to_array($subscriptions);
+        $this->assertInstanceOf(Subscription::class, $arr[0]);
+        $this->assertEquals($arr[0]->info()['name'], $subscriptionResult[0]['name']);
+        $this->assertEquals($arr[1]->info()['name'], $subscriptionResult[1]['name']);
+        $this->assertEquals($arr[2]->info()['name'], $subscriptionResult[2]['name']);
+    }
+
+    public function testSubscriptionsPaged()
+    {
+        $subscriptionResult = [
+            [
+                'name' => 'projects/project-name/subscriptions/subscription-a',
+                'topic' => 'projects/project-name/topics/topic-name'
+            ], [
+                'name' => 'projects/project-name/subscriptions/subscription-b',
+                'topic' => 'projects/project-name/topics/topic-name'
+            ], [
+                'name' => 'projects/project-name/subscriptions/subscription-c',
+                'topic' => 'projects/project-name/topics/topic-name'
+            ]
+        ];
+
+        $this->connection->listSubscriptionsByTopic(Argument::that(function ($options) {
+            if ($options['foo'] !== 'bar') return false;
+            if ($options['pageToken'] !== 'foo' && !is_null($options['pageToken'])) return false;
+
+            return true;
+        }))->willReturn([
+            'subscriptions' => $subscriptionResult,
+            'nextPageToken' => 'foo'
+        ])->shouldBeCalledTimes(2);
+
+        $topic = new Topic(
+            $this->connection->reveal(),
+            'topic-name',
+            'project-name'
+        );
+
+        $subscriptions = $topic->subscriptions([
+            'foo' => 'bar'
+        ]);
+
+        // enumerate the iterator and kill after it loops twice.
+        $arr = [];
+        $i = 0;
+        foreach ($subscriptions as $subscription) {
+            $i++;
+            $arr[] = $subscription;
+            if ($i == 6) break;
+        }
+
+        $this->assertEquals(6, count($arr));
+    }
+}

--- a/tests/RequestBuilderTest.php
+++ b/tests/RequestBuilderTest.php
@@ -68,6 +68,28 @@ class RequestBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"referenceProp":"reference"}', (string) $request->getBody());
     }
 
+    public function testBuildsNestedRequestWithStringSplitting()
+    {
+        $builder = new RequestBuilder(
+            __DIR__ . '/fixtures/service-fixture.json',
+            'http://www.example.com/',
+            ['resources', 'projects', 'otherThing']
+        );
+
+        $parameters = [
+            'queryParam' => 'query',
+            'pathParam' => 'path',
+            'referenceProp' => 'reference'
+        ];
+
+        $request = $builder->build('myOtherResource.resources.evenMoreNestedThing', 'evenMoreNestedResource', $parameters);
+        $uri = $request->getUri();
+
+        $this->assertEquals('/path', $uri->getPath());
+        $this->assertEquals('queryParam=query', $uri->getQuery());
+        $this->assertEquals('{"referenceProp":"reference"}', (string) $request->getBody());
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */

--- a/tests/RequestWrapperTest.php
+++ b/tests/RequestWrapperTest.php
@@ -213,4 +213,36 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
             new Request('GET', 'http://www.example.com')
         );
     }
+
+    /**
+     * @expectedException Google\Cloud\Exception\NotFoundException
+     */
+    public function testThrowsNotFoundException()
+    {
+        $requestWrapper = new RequestWrapper([
+            'httpHandler' => function ($request, $options = []) {
+                throw new \Exception('', 404);
+            }
+        ]);
+
+        $requestWrapper->send(
+            new Request('GET', 'http://www.example.com')
+        );
+    }
+
+    /**
+     * @expectedException Google\Cloud\Exception\ConflictException
+     */
+    public function testThrowsConflictException()
+    {
+        $requestWrapper = new RequestWrapper([
+            'httpHandler' => function ($request, $options = []) {
+                throw new \Exception('', 409);
+            }
+        ]);
+
+        $requestWrapper->send(
+            new Request('GET', 'http://www.example.com')
+        );
+    }
 }

--- a/tests/RestTraitTest.php
+++ b/tests/RestTraitTest.php
@@ -30,7 +30,7 @@ class RestTraitTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->implementation = new RestTraitImplementation;
+        $this->implementation = $this->getObjectForTrait(RestTrait::class);
         $this->requestWrapper = $this->prophesize('Google\Cloud\RequestWrapper');
         $this->requestBuilder = $this->prophesize('Google\Cloud\RequestBuilder');
         $this->requestBuilder->build(Argument::cetera())
@@ -66,9 +66,4 @@ class RestTraitTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(json_decode($responseBody, true), $actualResponse);
     }
-}
-
-class RestTraitImplementation
-{
-    use RestTrait;
 }

--- a/tests/ServiceBuilderTest.php
+++ b/tests/ServiceBuilderTest.php
@@ -46,12 +46,14 @@ class ServiceBuilderTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                'storage',
-                'Google\Cloud\Storage\StorageClient'
-            ],
-            [
                 'bigQuery',
                 'Google\Cloud\BigQuery\BigQueryClient'
+            ], [
+                'pubsub',
+                'Google\Cloud\PubSub\PubSubClient'
+            ], [
+                'storage',
+                'Google\Cloud\Storage\StorageClient'
             ]
         ];
     }

--- a/tests/UriTraitTest.php
+++ b/tests/UriTraitTest.php
@@ -25,7 +25,7 @@ class UriTraitTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->implementation = new UriTraitImplementation;
+        $this->implementation = $this->getObjectForTrait(UriTrait::class);
     }
 
     public function testExpandsUri()
@@ -57,9 +57,4 @@ class UriTraitTest extends \PHPUnit_Framework_TestCase
             ['?narf=true', ['narf' => true]]
         ];
     }
-}
-
-class UriTraitImplementation
-{
-    use UriTrait;
 }

--- a/tests/fixtures/service-fixture.json
+++ b/tests/fixtures/service-fixture.json
@@ -55,6 +55,30 @@
                   "$ref": "MyReference"
                 }
               }
+            },
+            "resources": {
+              "evenMoreNestedThing": {
+                "methods": {
+                  "evenMoreNestedResource": {
+                    "path": "{pathParam}",
+                    "httpMethod": "POST",
+                    "parameters": {
+                      "queryParam": {
+                        "type": "string",
+                        "location": "query"
+                      },
+                      "pathParam": {
+                        "type": "string",
+                        "required": true,
+                        "location": "path"
+                      }
+                    },
+                    "request": {
+                      "$ref": "MyReference"
+                    }
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
- [x] Implementation of Pub/Sub API
- [x] Test Coverage


### Big stuff:

* Preliminary pub/sub support
* Add different exception types and throw exception based on http status code. (When gRPC support starts coming, this will allow us to present a standard interface to end users).
* Extend my last change to the `RequestBuilder` to allow calling nested resource on a per-call basis.

## Still coming:

* Full test coverage is still in progress
* IAM support (Some of the objects are there now, but are not implemented in the pubsub classes and will change a lot before they're ready.)
* Some docblocks need more complete documentation of `array $options` possible values.

## More about that `RequestBuilder` thing I mentioned above

Some discovery documents nest resources fairly deeply. For instance, a call to list subscriptions by topics would look like `$schema['resources']['projects']['resources']['topics']['resources']['subscriptions']['methods']['list']`. To get to that level of nesting, we utilize the change I made to the `RequestWrapper` constructor in #38 (which applies to every resource call in the connection), and pair it with a string splitting strategy used on a per-call basis.

The end result is a connection call that looks like this:

````php
<?php

// this is in the constructor
$this->setRequestBuilder(new RequestBuilder(
    __DIR__ . '/ServiceDefinition/pubsub-v1.json',
    self::BASE_URI,
    ['resources', 'projects']
));

// this is in listSubscriptionsByTopic
return $this->send('topics.resources.subscriptions', 'list', $args);
````

This isn't ready for a merge yet, but I wanted to get it out there and get some more eyes on it! Thanks for any feedback.