### PR TITLE
Upgrade auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": ">=5.5",
     "rize/uri-template": "~0.3",
-    "google/auth": "dev-master",
+    "google/auth": "0.9",
     "guzzlehttp/guzzle": "~5.2|~6.0",
     "guzzlehttp/psr7": "1.2.*",
     "monolog/monolog": "~1",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": ">=5.5",
     "rize/uri-template": "~0.3",
-    "google/auth": "0.7",
+    "google/auth": "dev-master",
     "guzzlehttp/guzzle": "~5.2|~6.0",
     "guzzlehttp/psr7": "1.2.*",
     "monolog/monolog": "~1",

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\BigQuery;
 
 use Google\Cloud\BigQuery\Connection\ConnectionInterface;
 use Google\Cloud\BigQuery\Connection\Rest;
+use Google\Cloud\ClientTrait;
 
 /**
  * Google Cloud BigQuery client. Allows you to create, manage, share and query
@@ -27,6 +28,7 @@ use Google\Cloud\BigQuery\Connection\Rest;
  */
 class BigQueryClient
 {
+    use ClientTrait;
     use JobConfigurationTrait;
 
     const SCOPE = 'https://www.googleapis.com/auth/bigquery';
@@ -36,11 +38,6 @@ class BigQueryClient
      * @var ConnectionInterface $connection Represents a connection to BigQuery.
      */
     protected $connection;
-
-    /**
-     * @var string The project ID created in the Google Developers Console.
-     */
-    private $projectId;
 
     /**
      * Create a BigQuery client.
@@ -75,16 +72,11 @@ class BigQueryClient
      */
     public function __construct(array $config = [])
     {
-        if (!isset($config['projectId'])) {
-            throw new \InvalidArgumentException('A projectId is required.');
-        }
-
         if (!isset($config['scopes'])) {
             $config['scopes'] = [self::SCOPE];
         }
 
-        $this->connection = new Rest($config);
-        $this->projectId = $config['projectId'];
+        $this->connection = new Rest($this->configureAuthentication($config));
     }
 
     /**

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -65,16 +65,7 @@ trait ClientTrait
         $config += [
             'keyFile' => null,
             'keyFilePath' => null,
-            'scopes' => null,
-            'authHttpHandler' => null,
-            'httpHandler' => null,
         ];
-
-        if (!$config['httpHandler']) {
-            $config['httpHandler'] = HttpHandlerFactory::build();
-        }
-
-        $authHttpHandler = $config['authHttpHandler'] ?: $config['httpHandler'];
 
         if ($config['keyFile']) {
             return $config['keyFile'];

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -40,7 +40,6 @@ trait ClientTrait
     private function configureAuthentication(array $config)
     {
         $config['keyFile'] = $this->getKeyFile($config);
-        $config['credentialsFetcher'] = $this->getCredentials($config);
 
         $this->projectId = $this->detectProjectId($config);
 
@@ -97,28 +96,6 @@ trait ClientTrait
 
         return CredentialsLoader::fromEnv()
             ?: CredentialsLoader::fromWellKnownFile();
-    }
-
-    /**
-     * Create an instance of CredentialsLoader from a keyfile.
-     *
-     * @param  array $config
-     * @return CredentialsLoader
-     */
-    private function getCredentials(array $config)
-    {
-        if ($config['keyFile']) {
-            return CredentialsLoader::makeCredentials($config['scopes'], $config['keyFile']);
-        }
-
-        try {
-            return ApplicationDefaultCredentials::getCredentials(
-                $config['scopes'],
-                $authHttpHandler
-            );
-        } catch (\DomainException $ex) {
-            throw new GoogleException($ex->getMessage(), $ex->getCode(), $ex);
-        }
     }
 
     /**

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud;
+
+use Google\Auth\ApplicationDefaultCredentials;
+use Google\Auth\CredentialsLoader;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
+use Google\Cloud\Exception\ConfigException;
+use Google\Cloud\Exception\GoogleException;
+use GuzzleHttp\Psr7;
+
+trait ClientTrait
+{
+    /**
+     * @var string The project ID created in the Google Developers Console.
+     */
+    private $projectId;
+
+    /**
+     * Fetch and validate the keyfile and set the project ID.
+     *
+     * @param  array $config
+     * @return array
+     */
+    private function configureAuthentication(array $config)
+    {
+        $config['keyFile'] = $this->getKeyFile($config);
+        $config['credentialsFetcher'] = $this->getCredentials($config);
+
+        $this->projectId = $this->detectProjectId($config);
+
+        return $config;
+    }
+
+    /**
+     * Get a keyfile.
+     *
+     * Process:
+     * 1. If $config['keyFile'] is set, use that.
+     * 2. If $config['keyFilePath'] is set, load the file and use that.
+     * 3. If GOOGLE_APPLICATION_CREDENTIALS environment variable is set, load
+     *    from that location and use that.
+     * 4. If OS-specific well-known-file is set, load from that location and use
+     *    that.
+     * 5. Exception. :(
+     *
+     * @param  array $config
+     */
+    private function getKeyFile(array $config = [])
+    {
+        $config += [
+            'keyFile' => null,
+            'keyFilePath' => null,
+            'scopes' => null,
+            'authHttpHandler' => null,
+            'httpHandler' => null,
+        ];
+
+        if (!$config['httpHandler']) {
+            $config['httpHandler'] = HttpHandlerFactory::build();
+        }
+
+        $authHttpHandler = $config['authHttpHandler'] ?: $config['httpHandler'];
+
+        if ($config['keyFile']) {
+            return $config['keyFile'];
+        }
+
+        if ($config['keyFilePath']) {
+            if (!file_exists($config['keyFilePath'])) {
+                throw new GoogleException('Given keyfile path does not exist');
+            }
+
+            $keyFileData = json_decode(file_get_contents($config['keyFilePath']), true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new GoogleException('Given keyfile was invalid');
+            }
+
+            return $keyFileData;
+        }
+
+        return CredentialsLoader::fromEnv()
+            ?: CredentialsLoader::fromWellKnownFile();
+    }
+
+    /**
+     * Create an instance of CredentialsLoader from a keyfile.
+     *
+     * @param  array $config
+     * @return CredentialsLoader
+     */
+    private function getCredentials(array $config)
+    {
+        if ($config['keyFile']) {
+            return CredentialsLoader::makeCredentials($config['scopes'], $config['keyFile']);
+        }
+
+        try {
+            return ApplicationDefaultCredentials::getCredentials(
+                $config['scopes'],
+                $authHttpHandler
+            );
+        } catch (\DomainException $ex) {
+            throw new GoogleException($ex->getMessage(), $ex->getCode(), $ex);
+        }
+    }
+
+    /**
+     * Detect and return a project ID.
+     *
+     * Process:
+     * 1. If $config['projectId'] is set, use that.
+     * 2. If $config['keyFile'] is set, attempt to retrieve a project ID from
+     *    that.
+     * 3. Throw exception.
+     *
+     * @param  array $config
+     * @return string
+     * @throws GoogleException
+     */
+    private function detectProjectId(array $config)
+    {
+        $config += [
+            'projectId' => null,
+        ];
+
+        if ($config['projectId']) {
+            return $config['projectId'];
+        }
+
+        if ($config['keyFile'] && isset($config['keyFile']['project_id'])) {
+            return $config['keyFile']['project_id'];
+        }
+
+        throw new GoogleException(
+            'No project ID was provided, ' .
+            'and we were unable to detect a default project ID.'
+        );
+    }
+}

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -22,7 +22,6 @@ use Google\Auth\CredentialsLoader;
 use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Cloud\Compute\Metadata;
-use Google\Cloud\Exception\ConfigException;
 use Google\Cloud\Exception\GoogleException;
 use GuzzleHttp\Psr7;
 
@@ -113,7 +112,6 @@ trait ClientTrait
         $config += [
             'projectId' => null,
             'httpHandler' => null,
-            'keyFile' => null,
         ];
 
         if ($config['projectId']) {

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Exception;
  * Exception thrown when a request fails due to an error in the request.
  * In REST context, this exception indicates a status code 400.
  */
-class BadRequestException extends GoogleException
+class BadRequestException extends ServiceException
 {
 
 }

--- a/src/Exception/ConflictException.php
+++ b/src/Exception/ConflictException.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Exception;
  * Exception thrown when a request fails due to a conflict.
  * In REST context, this exception indicates a status code 409.
  */
-class ConflictException extends GoogleException
+class ConflictException extends ServiceException
 {
 
 }

--- a/src/Exception/GoogleException.php
+++ b/src/Exception/GoogleException.php
@@ -24,42 +24,5 @@ use Exception;
  */
 class GoogleException extends Exception
 {
-    /**
-     * @var Exception
-     */
-    private $serviceException;
 
-    /**
-     * Handle previous exceptions differently here.
-     *
-     * @param  string    $message
-     * @param  int       $code
-     * @param  Exception $serviceException
-     */
-    public function __construct($message, $code = null, Exception $serviceException = null)
-    {
-        $this->serviceException = $serviceException;
-
-        parent::__construct($message, $code);
-    }
-
-    /**
-     * If $serviceException is set, return true.
-     *
-     * @return bool
-     */
-    public function hasServiceException()
-    {
-        return ($this->serviceException);
-    }
-
-    /**
-     * Return the service exception object.
-     *
-     * @return Exception
-     */
-    public function getServiceException()
-    {
-        return $this->serviceException;
-    }
 }

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -20,7 +20,7 @@ namespace Google\Cloud\Exception;
 /**
  * Exception thrown when a resource is not found.
  */
-class NotFoundException extends GoogleException
+class NotFoundException extends ServiceException
 {
 
 }

--- a/src/Exception/ServerException.php
+++ b/src/Exception/ServerException.php
@@ -21,7 +21,7 @@ namespace Google\Cloud\Exception;
  * Exception thrown when a request fails due to an error on the server.
  * In REST context, this exception indicates a status code 500.
  */
-class ServerException extends GoogleException
+class ServerException extends ServiceException
 {
 
 }

--- a/src/Exception/ServiceException.php
+++ b/src/Exception/ServiceException.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Exception;
+
+/**
+ * Exception thrown when a request fails.
+ */
+class ServiceException extends GoogleException
+{
+    /**
+     * @var Exception
+     */
+    private $serviceException;
+
+    /**
+     * Handle previous exceptions differently here.
+     *
+     * @param  string    $message
+     * @param  int       $code
+     * @param  Exception $serviceException
+     */
+    public function __construct($message, $code = null, Exception $serviceException = null)
+    {
+        $this->serviceException = $serviceException;
+
+        parent::__construct($message, $code);
+    }
+
+    /**
+     * If $serviceException is set, return true.
+     *
+     * @return bool
+     */
+    public function hasServiceException()
+    {
+        return ($this->serviceException);
+    }
+
+    /**
+     * Return the service exception object.
+     *
+     * @return Exception
+     */
+    public function getServiceException()
+    {
+        return $this->serviceException;
+    }
+}

--- a/src/Exception/ServiceException.php
+++ b/src/Exception/ServiceException.php
@@ -50,7 +50,7 @@ class ServiceException extends GoogleException
      */
     public function hasServiceException()
     {
-        return ($this->serviceException);
+        return (bool) $this->serviceException;
     }
 
     /**

--- a/src/Exception/ServiceException.php
+++ b/src/Exception/ServiceException.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Exception;
 
+use Exception;
+
 /**
  * Exception thrown when a request fails.
  */

--- a/src/PubSub/PubSubClient.php
+++ b/src/PubSub/PubSubClient.php
@@ -17,8 +17,8 @@
 
 namespace Google\Cloud\PubSub;
 
-use Google\Cloud\PubSub\Connection\Rest;
 use Google\Cloud\ClientTrait;
+use Google\Cloud\PubSub\Connection\Rest;
 use InvalidArgumentException;
 
 /**

--- a/src/PubSub/PubSubClient.php
+++ b/src/PubSub/PubSubClient.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\PubSub;
 
 use Google\Cloud\PubSub\Connection\Rest;
+use Google\Cloud\ClientTrait;
 use InvalidArgumentException;
 
 /**
@@ -27,6 +28,7 @@ use InvalidArgumentException;
  */
 class PubSubClient
 {
+    use ClientTrait;
     use ResourceNameTrait;
 
     const FULL_CONTROL_SCOPE = 'https://www.googleapis.com/auth/pubsub';
@@ -35,11 +37,6 @@ class PubSubClient
      * @var ConnectionInterface
      */
     protected $connection;
-
-    /**
-     * @var string The project ID created in the Google Developers Console.
-     */
-    private $projectId;
 
     /**
      * Create a PubSub client.
@@ -84,16 +81,11 @@ class PubSubClient
      */
     public function __construct(array $config = [])
     {
-        if (!isset($config['projectId'])) {
-            throw new InvalidArgumentException('A projectId is required.');
-        }
-
         if (!isset($config['scopes'])) {
             $config['scopes'] = [self::FULL_CONTROL_SCOPE];
         }
 
-        $this->connection = new Rest($config);
-        $this->projectId = $config['projectId'];
+        $this->connection = new Rest($this->configureAuthentication($config));
     }
 
     /**

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -92,9 +92,6 @@ class RequestWrapper
      *           credentials .json file retrieved from the Google Developers
      *           Console.
      *     @type array $httpOptions HTTP client specific configuration options.
-     *     @type string $keyFilePath The full path to your service account
-     *           credentials .json file retrieved from the Google Developers
-     *           Console.
      *     @type int $retries Number of retries for a failed request. Defaults
      *           to 3.
      *     @type array $scopes Scopes to be used for the request.
@@ -232,7 +229,7 @@ class RequestWrapper
      * Convert any exception to a Google Exception.
      *
      * @param  \Exception $ex
-     * @param  GoogleException
+     * @return  GoogleException
      */
     private function convertToGoogleException(\Exception $ex)
     {

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -109,12 +109,11 @@ class RequestWrapper
             'httpHandler' => null,
             'httpOptions' => [],
             'keyFile' => null,
-            'keyFilePath' => null,
             'retries' => null,
             'scopes' => null
         ];
 
-        if (!$config['credentialsFetcher'] instanceof FetchAuthTokenInterface) {
+        if ($config['credentialsFetcher'] && !$config['credentialsFetcher'] instanceof FetchAuthTokenInterface) {
             throw new \InvalidArgumentException('credentialsFetcher must implement FetchAuthTokenInterface.');
         }
 
@@ -125,6 +124,7 @@ class RequestWrapper
         $this->httpOptions = $config['httpOptions'];
         $this->retries = $config['retries'];
         $this->scopes = $config['scopes'];
+        $this->keyFile = $config['keyFile'];
     }
 
     /**
@@ -168,9 +168,8 @@ class RequestWrapper
             return $this->credentialsFetcher;
         }
 
-        if ($this->keyFileStream) {
-            $this->keyFileStream->rewind();
-            return CredentialsLoader::makeCredentials($this->scopes, $this->keyFileStream);
+        if ($this->keyFile) {
+            return CredentialsLoader::makeCredentials($this->scopes, $this->keyFile);
         }
 
         return ApplicationDefaultCredentials::getCredentials($this->scopes, $this->authHttpHandler);
@@ -219,7 +218,7 @@ class RequestWrapper
     private function fetchCredentials()
     {
         try {
-            $credentials = $this->credentialsFetcher->fetchAuthToken($this->authHttpHandler);
+            $credentials = $this->getCredentialsFetcher()->fetchAuthToken($this->authHttpHandler);
         } catch (\Exception $ex) {
             throw $this->convertToGoogleException($ex);
         }

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -114,7 +114,7 @@ class RequestWrapper
             'scopes' => null
         ];
 
-        if ($config['credentialsFetcher'] && !$config['credentialsFetcher'] instanceof FetchAuthTokenInterface) {
+        if (!$config['credentialsFetcher'] instanceof FetchAuthTokenInterface) {
             throw new \InvalidArgumentException('credentialsFetcher must implement FetchAuthTokenInterface.');
         }
 
@@ -125,10 +125,6 @@ class RequestWrapper
         $this->httpOptions = $config['httpOptions'];
         $this->retries = $config['retries'];
         $this->scopes = $config['scopes'];
-
-        if ($config['keyFile'] || $config['keyFilePath']) {
-            $this->keyFileStream = Psr7\stream_for($config['keyFile'] ?: fopen($config['keyFilePath'], 'r'));
-        }
     }
 
     /**
@@ -223,7 +219,7 @@ class RequestWrapper
     private function fetchCredentials()
     {
         try {
-            $credentials = $this->getCredentialsFetcher()->fetchAuthToken($this->authHttpHandler);
+            $credentials = $this->credentialsFetcher->fetchAuthToken($this->authHttpHandler);
         } catch (\Exception $ex) {
             throw $this->convertToGoogleException($ex);
         }

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -65,10 +65,10 @@ class RequestWrapper
     private $httpOptions;
 
     /**
-     * @var StreamInterface Points to the keyfile downloaded from the Google
-     * Developer's Console.
+     * @var array The contents of the service account
+     * credentials .json file retrieved from the Google Developers Console.
      */
-    private $keyFileStream;
+    private $keyFile;
 
     /**
      * @var int Number of retries for a failed request. Defaults to 3.
@@ -229,7 +229,7 @@ class RequestWrapper
      * Convert any exception to a Google Exception.
      *
      * @param  \Exception $ex
-     * @return  GoogleException
+     * @return  ServiceException
      */
     private function convertToGoogleException(\Exception $ex)
     {
@@ -251,7 +251,7 @@ class RequestWrapper
                 break;
 
             default:
-                $exception = Exception\GoogleException::class;
+                $exception = Exception\ServiceException::class;
                 break;
         }
 

--- a/src/Storage/StorageClient.php
+++ b/src/Storage/StorageClient.php
@@ -17,6 +17,7 @@
 
 namespace Google\Cloud\Storage;
 
+use Google\Cloud\ClientTrait;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
 use Google\Cloud\Storage\Connection\Rest;
 
@@ -27,6 +28,8 @@ use Google\Cloud\Storage\Connection\Rest;
  */
 class StorageClient
 {
+    use ClientTrait;
+
     const FULL_CONTROL_SCOPE = 'https://www.googleapis.com/auth/devstorage.full_control';
     const READ_ONLY_SCOPE = 'https://www.googleapis.com/auth/devstorage.read_only';
     const READ_WRITE_SCOPE = 'https://www.googleapis.com/auth/devstorage.read_write';
@@ -35,11 +38,6 @@ class StorageClient
      * @var ConnectionInterface $connection Represents a connection to Storage.
      */
     protected $connection;
-
-    /**
-     * @var string The project ID created in the Google Developers Console.
-     */
-    private $projectId;
 
     /**
      * Create a Storage client.
@@ -74,16 +72,11 @@ class StorageClient
      */
     public function __construct(array $config = [])
     {
-        if (!isset($config['projectId'])) {
-            throw new \InvalidArgumentException('A projectId is required.');
-        }
-
         if (!isset($config['scopes'])) {
             $config['scopes'] = [self::FULL_CONTROL_SCOPE];
         }
 
-        $this->connection = new Rest($config);
-        $this->projectId = $config['projectId'];
+        $this->connection = new Rest($this->configureAuthentication($config));
     }
 
     /**

--- a/tests/BigQuery/BigQueryClientTest.php
+++ b/tests/BigQuery/BigQueryClientTest.php
@@ -38,14 +38,6 @@ class BigQueryClientTest extends \PHPUnit_Framework_TestCase
         $this->client = new BigQueryTestClient(['projectId' => $this->projectId]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testThrowsExceptionWithoutProjectId()
-    {
-        $client = new BigQueryClient();
-    }
-
     public function testRunsQuery()
     {
         $this->connection->query(Argument::any())

--- a/tests/ClientTraitTest.php
+++ b/tests/ClientTraitTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests;
+
+use Google\Cloud\ClientTrait;
+
+class ClientTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConfigureAuthentication()
+    {
+        $keyFilePath = __DIR__ . '/fixtures/json-key-fixture.json';
+        putenv("GOOGLE_APPLICATION_CREDENTIALS=$keyFilePath"); // for application default credentials
+
+        $trait = new ClientTraitStub;
+        $conf = $trait->runConfigureAuthentication([]);
+
+        $this->assertEquals(json_decode(file_get_contents($keyFilePath), true), $conf['keyFile']);
+        $this->assertEquals('example_project', $trait->getProjectId());
+    }
+
+    public function testConfigureAuthenticationWithKeyFile()
+    {
+        $keyFilePath = __DIR__ . '/fixtures/json-key-fixture.json';
+        $keyFile = json_decode(file_get_contents($keyFilePath), true);
+        $keyFile['project_id'] = 'test';
+
+        $trait = new ClientTraitStub;
+        $conf = $trait->runConfigureAuthentication([
+            'keyFile' => $keyFile
+        ]);
+
+        $this->assertEquals($keyFile, $conf['keyFile']);
+        $this->assertEquals('test', $trait->getProjectId());
+    }
+
+    public function testConfigureAuthenticationWithKeyFilePath()
+    {
+        $keyFilePath = __DIR__ . '/fixtures/json-key-fixture.json';
+        $keyFile = json_decode(file_get_contents($keyFilePath), true);
+
+        $trait = new ClientTraitStub;
+        $conf = $trait->runConfigureAuthentication([
+            'keyFilePath' => $keyFilePath
+        ]);
+
+        $this->assertEquals($keyFile, $conf['keyFile']);
+        $this->assertEquals('example_project', $trait->getProjectId());
+    }
+
+    /**
+     * @expectedException Google\Cloud\Exception\GoogleException
+     */
+    public function testConfigureAuthenticationWithInvalidKeyFilePath()
+    {
+        $keyFilePath = __DIR__ . '/i/sure/hope/this/doesnt/exist';
+
+        $trait = new ClientTraitStub;
+        $conf = $trait->runConfigureAuthentication([
+            'keyFilePath' => $keyFilePath
+        ]);
+    }
+
+    /**
+     * @expectedException Google\Cloud\Exception\GoogleException
+     */
+    public function testConfigureAuthenticationWithKeyFileThatCantBeDecoded()
+    {
+        $keyFilePath = __DIR__ . '/ClientTraitTest.php';
+
+        $trait = new ClientTraitStub;
+        $conf = $trait->runConfigureAuthentication([
+            'keyFilePath' => $keyFilePath
+        ]);
+    }
+
+    /**
+     * @expectedException Google\Cloud\Exception\GoogleException
+     */
+    public function testDetectProjectIdWithNoProjectIdAvailable()
+    {
+        $keyFilePath = __DIR__ . '/fixtures/json-key-fixture.json';
+        $keyFile = json_decode(file_get_contents($keyFilePath), true);
+        unset($keyFile['project_id']);
+
+        $trait = new ClientTraitStub;
+        $conf = $trait->runDetectProjectId([
+            'keyFile' => $keyFile
+        ]);
+    }
+}
+
+class ClientTraitStub
+{
+    use ClientTrait;
+
+    public function getProjectId()
+    {
+        return $this->projectId;
+    }
+
+    public function runConfigureAuthentication($config)
+    {
+        return $this->configureAuthentication($config);
+    }
+
+    public function runDetectProjectId($config)
+    {
+        return $this->detectProjectId($config);
+    }
+}

--- a/tests/Exception/ServiceExceptionTest.php
+++ b/tests/Exception/ServiceExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Exception;
+
+use Google\Cloud\Exception\ServiceException;
+
+class ServiceExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHasServiceException()
+    {
+        $previous = new \Exception('test');
+
+        $ex = new ServiceException('foo', 123, $previous);
+        $this->assertTrue($ex->hasServiceException());
+
+        $this->assertEquals($previous, $ex->getServiceException());
+    }
+
+    public function testDoesntHaveServiceException()
+    {
+        $ex = new ServiceException('foo');
+        $this->assertFalse($ex->hasServiceException());
+    }
+}

--- a/tests/PubSub/PubSubClientTest.php
+++ b/tests/PubSub/PubSubClientTest.php
@@ -37,14 +37,6 @@ class PubSubClientTest extends \PHPUnit_Framework_TestCase
         $this->client = new PubSubClientStub(['projectId' => 'project']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testWithMissingProjectId()
-    {
-        new PubSubClient([]);
-    }
-
     public function testCreateTopic()
     {
         $topicName = 'test-topic';

--- a/tests/RequestWrapperTest.php
+++ b/tests/RequestWrapperTest.php
@@ -195,9 +195,6 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Google\Cloud\Exception\GoogleException
-     */
     public function testThrowsExceptionWhenFetchingCredentialsFails()
     {
         $requestWrapper = new RequestWrapper([

--- a/tests/RequestWrapperTest.php
+++ b/tests/RequestWrapperTest.php
@@ -136,7 +136,7 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
             ->willReturn(['access_token' => 'abc']);
 
         return [
-            [$config + ['keyFile' => file_get_contents($keyFilePath)]], // keyFile
+            [$config + ['keyFile' => json_decode(file_get_contents($keyFilePath), true)]], // keyFile
             [$config + ['keyFilePath' => $keyFilePath]], //keyFilePath
             [$config + ['credentialsFetcher' => $credentialsFetcher->reveal()]], // user supplied fetcher
             [$config] // application default
@@ -157,7 +157,7 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
         $keyFilePath = __DIR__ . '/fixtures/json-key-fixture.json';
 
         return [
-            [$config + ['keyFile' => file_get_contents($keyFilePath)]], // keyFile
+            [$config + ['keyFile' => json_decode(file_get_contents($keyFilePath), true)]], // keyFile
             [$config + ['keyFilePath' => $keyFilePath]], //keyFilePath
         ];
     }
@@ -195,6 +195,9 @@ class RequestWrapperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @expectedException Google\Cloud\Exception\GoogleException
+     */
     public function testThrowsExceptionWhenFetchingCredentialsFails()
     {
         $requestWrapper = new RequestWrapper([

--- a/tests/fixtures/json-key-fixture.json
+++ b/tests/fixtures/json-key-fixture.json
@@ -1,1 +1,1 @@
-{"type":"authorized_user","client_id":"example@example.com","client_secret":"example","refresh_token":"abc"}
+{"type":"authorized_user","client_id":"example@example.com","client_secret":"example","refresh_token":"abc","project_id":"example_project"}


### PR DESCRIPTION
Upgrade gcloud-php to use Google/Auth@0.9. Includes auto-detection of project ID, when possible, so it fixes #32.

All service-related exceptions (i.e. `Google\Cloud\Exception\NotFoundException` and anything else that wraps a guzzle exception for REST, and in the future wraps a grpc/toolkit exception for gRPC) now extend `Google\Cloud\Exception\ServiceException` rather than `Google\Cloud\Exception\GoogleException`.

`ServiceException` includes the optional 3rd parameter `$serviceException` for passing the base service exception (from guzzle or toolkit code) up to the user. `GoogleException` can be used directly for non-service related library errors. I use it for when a projectId isn't provided and one cannot be detected, for instance.