### PR TITLE
Show coverage status for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Google Cloud PHP Client
-[![Travis Build Status](https://travis-ci.org/GoogleCloudPlatform/gcloud-php.svg)](https://travis-ci.org/GoogleCloudPlatform/gcloud-php/) [![Coverage Status](https://coveralls.io/repos/github/GoogleCloudPlatform/gcloud-php/badge.svg?branch=master)](https://coveralls.io/github/GoogleCloudPlatform/gcloud-php?branch=master)
+[![Travis Build Status](https://travis-ci.org/GoogleCloudPlatform/gcloud-php.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/gcloud-php/) [![Coverage Status](https://coveralls.io/repos/github/GoogleCloudPlatform/gcloud-php/badge.svg?branch=master)](https://coveralls.io/github/GoogleCloudPlatform/gcloud-php?branch=master)
 
 
 > Idiomatic PHP client for [Google Cloud Platform](https://cloud.google.com/) services.


### PR DESCRIPTION
Repository homepage is showing a build error even though master is good because the last build was a PR that errored.