### PR TITLE
Fix subscription list method and add name() methods

### DIFF
--- a/src/PubSub/Subscription.php
+++ b/src/PubSub/Subscription.php
@@ -146,6 +146,21 @@ class Subscription
     }
 
     /**
+     * Get the subscription name
+     *
+     * Example:
+     * ```
+     * echo $subscription->name();
+     * ```
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return $this->name;
+    }
+
+    /**
      * Execute a service request creating the subscription.
      *
      * The suggested way of creating a subscription is by calling through

--- a/src/PubSub/Topic.php
+++ b/src/PubSub/Topic.php
@@ -113,6 +113,21 @@ class Topic
     }
 
     /**
+     * Get the topic name
+     *
+     * Example:
+     * ```
+     * echo $topic->name();
+     * ```
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return $this->name;
+    }
+
+    /**
      * Create a topic.
      *
      * Example:
@@ -420,7 +435,7 @@ class Topic
             ]);
 
             foreach ($response['subscriptions'] as $subscription) {
-                yield $this->subscriptionFactory($subscription['name'], $subscription);
+                yield $this->subscriptionFactory($subscription);
             }
 
             // If there's a page token, we'll request the next page.

--- a/tests/PubSub/SubscriptionTest.php
+++ b/tests/PubSub/SubscriptionTest.php
@@ -32,6 +32,12 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
         $this->connection = $this->prophesize('Google\Cloud\PubSub\Connection\ConnectionInterface');
     }
 
+    public function testName()
+    {
+        $subscription = new Subscription($this->connection->reveal(), 'test-subscription-name', 'test-topic-name', 'my-project');
+        $this->assertEquals($subscription->name(), 'projects/my-project/subscriptions/test-subscription-name');
+    }
+
     public function testCreate()
     {
         $this->connection->createSubscription(Argument::withEntry('foo', 'bar'))

--- a/tests/PubSub/TopicTest.php
+++ b/tests/PubSub/TopicTest.php
@@ -33,6 +33,12 @@ class TopicTest extends \PHPUnit_Framework_TestCase
         $this->connection = $this->prophesize('Google\Cloud\PubSub\Connection\ConnectionInterface');
     }
 
+    public function testName()
+    {
+        $topic = new Topic($this->connection->reveal(), 'test-topic-name', 'my-project');
+        $this->assertEquals($topic->name(), 'projects/my-project/topics/test-topic-name');
+    }
+
     public function testCreate()
     {
         $this->connection->createTopic(Argument::withEntry('foo', 'bar'))
@@ -299,16 +305,9 @@ class TopicTest extends \PHPUnit_Framework_TestCase
     public function testSubscriptions()
     {
         $subscriptionResult = [
-            [
-                'name' => 'projects/project-name/subscriptions/subscription-a',
-                'topic' => 'projects/project-name/topics/topic-name'
-            ], [
-                'name' => 'projects/project-name/subscriptions/subscription-b',
-                'topic' => 'projects/project-name/topics/topic-name'
-            ], [
-                'name' => 'projects/project-name/subscriptions/subscription-c',
-                'topic' => 'projects/project-name/topics/topic-name'
-            ]
+            'projects/project-name/subscriptions/subscription-a',
+            'projects/project-name/subscriptions/subscription-b',
+            'projects/project-name/subscriptions/subscription-c',
         ];
 
         $this->connection->listSubscriptionsByTopic(Argument::withEntry('foo', 'bar'))
@@ -330,24 +329,17 @@ class TopicTest extends \PHPUnit_Framework_TestCase
 
         $arr = iterator_to_array($subscriptions);
         $this->assertInstanceOf(Subscription::class, $arr[0]);
-        $this->assertEquals($arr[0]->info()['name'], $subscriptionResult[0]['name']);
-        $this->assertEquals($arr[1]->info()['name'], $subscriptionResult[1]['name']);
-        $this->assertEquals($arr[2]->info()['name'], $subscriptionResult[2]['name']);
+        $this->assertEquals($arr[0]->name(), $subscriptionResult[0]);
+        $this->assertEquals($arr[1]->name(), $subscriptionResult[1]);
+        $this->assertEquals($arr[2]->name(), $subscriptionResult[2]);
     }
 
     public function testSubscriptionsPaged()
     {
         $subscriptionResult = [
-            [
-                'name' => 'projects/project-name/subscriptions/subscription-a',
-                'topic' => 'projects/project-name/topics/topic-name'
-            ], [
-                'name' => 'projects/project-name/subscriptions/subscription-b',
-                'topic' => 'projects/project-name/topics/topic-name'
-            ], [
-                'name' => 'projects/project-name/subscriptions/subscription-c',
-                'topic' => 'projects/project-name/topics/topic-name'
-            ]
+            'projects/project-name/subscriptions/subscription-a',
+            'projects/project-name/subscriptions/subscription-b',
+            'projects/project-name/subscriptions/subscription-c',
         ];
 
         $this->connection->listSubscriptionsByTopic(Argument::that(function ($options) {


### PR DESCRIPTION
* Dave found a bug in Topic::subscriptions(). The iterator was expecting $subscription to be an array, but the API returns a string. This is fixed.
* I added a name() method to Topic and Subscription. There was not an easy way to get the name of either type without calling info(), which in many cases will trigger an API call. The new method will expose the name without needing a service call.