### PR TITLE
pass null instead of empty array to Request

### DIFF
--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -117,7 +117,7 @@ class RequestBuilder
             $action['httpMethod'],
             $uri,
             ['Content-Type' => 'application/json'],
-            $body ? json_encode($body) : []
+            $body ? json_encode($body) : null
         );
     }
 


### PR DESCRIPTION
In the case where a request body does not exist it is not valid to pass an empty array.