### PR TITLE
Moves Request-specific logic out of ExponentialBackoff

### DIFF
--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -159,13 +159,12 @@ class RequestWrapper
     {
         $retries = isset($options['retries']) ? $options['retries'] : $this->retries;
         $httpOptions = isset($options['httpOptions']) ? $options['httpOptions'] : $this->httpOptions;
-        $backoff = new ExponentialBackoff($retries);
+        $backoff = new ExponentialBackoff($retries, $this->getRetryFunction());
 
         $signedRequest = $this->signRequest($request);
-        $retryFunction = $this->getRetryFunction();
 
         try {
-            return $backoff->execute($this->httpHandler, [$signedRequest, $httpOptions], $retryFunction);
+            return $backoff->execute($this->httpHandler, [$signedRequest, $httpOptions]);
         } catch (\Exception $ex) {
             throw $this->convertToGoogleException($ex);
         }

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -73,7 +73,25 @@ class RequestWrapper
     /**
      * @var int Number of retries for a failed request. Defaults to 3.
      */
+
     private $retries;
+    /**
+     * @var array
+     */
+    private $httpRetryCodes = [
+        500,
+        502,
+        503,
+        504
+    ];
+
+    /**
+     * @var array
+     */
+    private $httpRetryMessages = [
+        'rateLimitExceeded',
+        'userRateLimitExceeded'
+    ];
 
     /**
      * @var array Scopes to be used for the request.
@@ -144,9 +162,10 @@ class RequestWrapper
         $backoff = new ExponentialBackoff($retries);
 
         $signedRequest = $this->signRequest($request);
+        $retryFunction = $this->getRetryFunction();
 
         try {
-            return $backoff->execute($this->httpHandler, [$signedRequest, $httpOptions]);
+            return $backoff->execute($this->httpHandler, [$signedRequest, $httpOptions], $retryFunction);
         } catch (\Exception $ex) {
             throw $this->convertToGoogleException($ex);
         }
@@ -256,5 +275,40 @@ class RequestWrapper
         }
 
         return new $exception($ex->getMessage(), $ex->getCode(), $ex);
+    }
+
+
+
+    /**
+     * Determines whether or not the request should be retried.
+     *
+     * @param \Exception $ex
+     * @return bool
+     */
+    private function getRetryFunction()
+    {
+        $httpRetryCodes = $this->httpRetryCodes;
+        $httpRetryMessages = $this->httpRetryMessages;
+        return function (\Exception $ex) use ($httpRetryCodes, $httpRetryMessages) {
+            $statusCode = $ex->getCode();
+
+            if (in_array($statusCode, $httpRetryCodes)) {
+                return true;
+            }
+
+            $message = json_decode($ex->getMessage(), true);
+
+            if (!isset($message['error']['errors'])) {
+                return false;
+            }
+
+            foreach ($message['error']['errors'] as $error) {
+                if (in_array($error['reason'], $httpRetryMessages)) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
     }
 }

--- a/tests/ExponentialBackoffTest.php
+++ b/tests/ExponentialBackoffTest.php
@@ -71,19 +71,21 @@ class ExponentialBackoffTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function testThrowsExceptionWithNonRetryableError()
+    public function testThrowsExceptionWhenRetryFunctionReturnsFalse()
     {
-        $nonRetryableErrorMessage = '{"error": {"errors": [{"reason": "notAGoodEnoughReason"}]}}';
         $actualAttempts = 0;
         $hasTriggeredException = false;
         $backoff = new ExponentialBackoff();
         $backoff->setDelayFunction($this->delayFunction);
+        $retryFunction = function(\Exception $ex) {
+            return false;
+        };
 
         try {
-            $backoff->execute(function () use (&$actualAttempts, $nonRetryableErrorMessage) {
+            $backoff->execute(function () use (&$actualAttempts) {
                 $actualAttempts++;
-                throw new \Exception($nonRetryableErrorMessage, 429);
-            });
+                throw new \Exception();
+            }, [], $retryFunction);
         } catch (\Exception $ex) {
             $hasTriggeredException = true;
         }

--- a/tests/ExponentialBackoffTest.php
+++ b/tests/ExponentialBackoffTest.php
@@ -75,17 +75,17 @@ class ExponentialBackoffTest extends \PHPUnit_Framework_TestCase
     {
         $actualAttempts = 0;
         $hasTriggeredException = false;
-        $backoff = new ExponentialBackoff();
-        $backoff->setDelayFunction($this->delayFunction);
         $retryFunction = function(\Exception $ex) {
             return false;
         };
+        $backoff = new ExponentialBackoff(null, $retryFunction);
+        $backoff->setDelayFunction($this->delayFunction);
 
         try {
             $backoff->execute(function () use (&$actualAttempts) {
                 $actualAttempts++;
                 throw new \Exception();
-            }, [], $retryFunction);
+            });
         } catch (\Exception $ex) {
             $hasTriggeredException = true;
         }


### PR DESCRIPTION
Toying with the idea of using `ExponentialBackoff` for polling jobs. What do you guys think? 

Usage:

```php
$backoff = new ExponentialBackoff(10);
$backoff->execute(function () use ($job) {
    printf('Waiting for job to complete' . PHP_EOL);
    $job->reload();
    if (!$job->isComplete()) {
        throw new \Exception('Failed to complete job: Maximum retries exceeded');
    }
});
```

In this example, the job is retried 10 times and then throws the exception.