### PR TITLE
RFC: adds bigquery projects

### DIFF
--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -325,6 +325,46 @@ class BigQueryClient
     }
 
     /**
+     * Fetches all BigQuery projects.
+     *
+     * Example:
+     * ```
+     * $projects = $bigQuery->projects();
+     *
+     * foreach ($projects as $project) {
+     *     var_dump($project['id']);
+     * }
+     * ```
+     *
+     * @see https://cloud.google.com/bigquery/docs/reference/v2/projects Projects list API documentation.
+     *
+     * @param array $options {
+     *     Configuration options.
+     *
+     *     @type int $maxResults Maximum number of results to return.
+     * }
+     * @return \Generator
+     */
+    public function projects(array $options = [])
+    {
+        $options['pageToken'] = null;
+
+        do {
+            $response = $this->connection->listProjects($options);
+
+            if (!isset($response['projects'])) {
+                return;
+            }
+
+            foreach ($response['projects'] as $project) {
+                yield $project;
+            }
+
+            $options['pageToken'] = isset($response['nextPageToken']) ? $response['nextPageToken'] : null;
+        } while ($options['pageToken']);
+    }
+
+    /**
      * Creates a dataset.
      *
      * Example:

--- a/src/BigQuery/Connection/Rest.php
+++ b/src/BigQuery/Connection/Rest.php
@@ -56,6 +56,15 @@ class Rest implements ConnectionInterface
      * @param array $args
      * @return array
      */
+    public function listProjects(array $args = [])
+    {
+        return $this->send('projects', 'list', $args);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
     public function deleteDataset(array $args = [])
     {
         return $this->send('datasets', 'delete', $args);


### PR DESCRIPTION
Hey guys,
We have an API for requesting bigquery projects, i.e.:

```php
$bigQuery = $service->bigQuery();
$projects = $bigQuery->projects();
```

This returns an array because there is no generic `Projects` object AFAIK. 