### PR TITLE
Support Generator type docs in return

### DIFF
--- a/scripts/DocGenerator.php
+++ b/scripts/DocGenerator.php
@@ -437,6 +437,16 @@ class DocGenerator
             if (substr_compare($type, '\Google\Cloud', 0, 13) === 0) {
                 $type = $this->buildLink($type);
             }
+
+            $matches = [];
+            if (preg_match('/\\\\?Generator\<(.*?)\>/', $type, $matches)) {
+                $typeLink = $matches[1];
+                if (strpos($matches[1], '\\') !== FALSE) {
+                    $typeLink = $this->buildLink($matches[1]);
+                }
+
+                $type = sprintf(htmlentities('Generator<%s>'), $typeLink);
+            }
         }
 
         return $types;

--- a/src/BigQuery/BigQueryClient.php
+++ b/src/BigQuery/BigQueryClient.php
@@ -234,7 +234,7 @@ class BigQueryClient
      *     @type string $stateFilter Filter for job state. Maybe be either
      *           `done`, `pending`, or `running`.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\BigQuery\Job>
      */
     public function jobs(array $options = [])
     {
@@ -298,7 +298,7 @@ class BigQueryClient
      *     @type bool $all Whether to list all datasets, including hidden ones.
      *     @type int $maxResults Maximum number of results to return.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\BigQuery\Dataset>
      */
     public function datasets(array $options = [])
     {

--- a/src/BigQuery/Dataset.php
+++ b/src/BigQuery/Dataset.php
@@ -163,7 +163,7 @@ class Dataset
      *
      *     @type int $maxResults Maximum number of results to return.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\BigQuery\Table>
      */
     public function tables(array $options = [])
     {

--- a/src/BigQuery/Table.php
+++ b/src/BigQuery/Table.php
@@ -121,7 +121,7 @@ class Table
      *     @type int $maxResults Maximum number of results to return.
      *     @type int $startIndex Zero-based index of the starting row.
      * }
-     * @return \Generator
+     * @return \Generator<array>
      */
     public function rows(array $options = [])
     {

--- a/src/Logging/LoggingClient.php
+++ b/src/Logging/LoggingClient.php
@@ -164,7 +164,7 @@ class LoggingClient
      *
      *     @type int $pageSize The maximum number of results to return per request.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\Logging\Sink>
      */
     public function sinks(array $options = [])
     {
@@ -253,7 +253,7 @@ class LoggingClient
      *
      *     @type int $pageSize The maximum number of results to return per request.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\Logging\Metric>
      */
     public function metrics(array $options = [])
     {
@@ -314,7 +314,7 @@ class LoggingClient
      *     @type int $pageSize The maximum number of results to return per
      *           request.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\Logging\Entry>
      */
     public function entries(array $options = [])
     {

--- a/src/PubSub/PubSubClient.php
+++ b/src/PubSub/PubSubClient.php
@@ -158,7 +158,7 @@ class PubSubClient
      *     @type int $pageSize Maximum number of results to return per
      *           request.
      * }
-     * @return Generator
+     * @return Generator<Google\Cloud\PubSub\Topic>
      */
     public function topics(array $options = [])
     {
@@ -255,7 +255,7 @@ class PubSubClient
      *     @type int $pageSize Maximum number of results to return per
      *           request.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\PubSub\Subscription>
      */
     public function subscriptions(array $options = [])
     {

--- a/src/PubSub/Subscription.php
+++ b/src/PubSub/Subscription.php
@@ -347,7 +347,9 @@ class Subscription
      *            wait until new messages are available.
      *      @type int  $maxMessages Limit the amount of messages pulled.
      * }
-     * @return \Generator
+     * @codeStandardsIgnoreStart
+     * @return \Generator<array> [ReceivedMessage](https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull#ReceivedMessage)
+     * @codeStandardsIgnoreEnd
      */
     public function pull(array $options = [])
     {

--- a/src/PubSub/Topic.php
+++ b/src/PubSub/Topic.php
@@ -423,7 +423,7 @@ class Topic
      *
      *     @type int $pageSize Maximum number of subscriptions to return.
      * }
-     * @return \Generator Populated with Subscription objects
+     * @return \Generator<Google\Cloud\PubSub\Subscription>
      */
     public function subscriptions(array $options = [])
     {

--- a/src/Storage/Bucket.php
+++ b/src/Storage/Bucket.php
@@ -327,7 +327,7 @@ class Bucket
      *     @type string $fields Selector which will cause the response to only
      *           return the specified fields.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\Storage\Object>
      */
     public function objects(array $options = [])
     {

--- a/src/Storage/StorageClient.php
+++ b/src/Storage/StorageClient.php
@@ -129,7 +129,7 @@ class StorageClient
      *     @type string $fields Selector which will cause the response to only
      *           return the specified fields.
      * }
-     * @return \Generator
+     * @return \Generator<Google\Cloud\Storage\Bucket>
      */
     public function buckets(array $options = [])
     {

--- a/src/Vision/VisionClient.php
+++ b/src/Vision/VisionClient.php
@@ -241,7 +241,7 @@ class VisionClient
      * @param  Image[] $images An array consisting of instances of
      *         {@see Google\Cloud\Vision\Image}.
      * @param  array $options Configuration Options
-     * @return \Generator
+     * @return \Generator<Google\Cloud\Vision\Annotation>
      */
     public function annotateBatch(array $images, array $options = [])
     {
@@ -265,7 +265,7 @@ class VisionClient
      * Generate a response to an annotation request.
      *
      * @param array $res The response object
-     * @return \Generator
+     * @return \Generator<Google\Cloud\Vision\Annotation>
      */
     private function respond(array $res)
     {


### PR DESCRIPTION
Until now, methods returning Generators have been missing information about what type of value is yielded. This change updates the doc generator to render type information in Generators.

Example:

![screen shot 2016-08-18 at 2 57 46 pm](https://cloud.githubusercontent.com/assets/89034/17786755/439205d8-6554-11e6-86db-4822ced52f9f.png)

Your PHPdoc should look like this:

````
 * @return \Generator<Google\Cloud\Veneer\ClassName>
````

The leading slash in `\Generator` is optional, but should be used for correctness.